### PR TITLE
Perform fingerprinting and modification at the end.

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -18,6 +18,10 @@ pub enum ChecksumError {
 pub struct FileChecksum {
     /// Hex encoded.
     pub sha256: String,
+    /// Modification time captured after checksumming (guaranteed stable during checksum).
+    pub mtime: std::time::SystemTime,
+    /// File size in bytes.
+    pub size: u64,
 }
 
 /// Computes the SHA-256 checksum of a file with concurrent modification detection.
@@ -73,7 +77,11 @@ pub fn checksum_file(path: &Path) -> Result<FileChecksum, ChecksumError> {
     let hash_bytes = hasher.finalize();
     let sha256 = format!("{:x}", hash_bytes);
 
-    Ok(FileChecksum { sha256 })
+    Ok(FileChecksum {
+        sha256,
+        mtime: mtime_after,
+        size: metadata_after.len(),
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,12 +134,12 @@ fn handle_status(
         status::StatusMode::Interesting
     };
 
-    let result = status::compute_status(&path, policy, mode)?;
+    let result = status::compute_status(&path, policy, mode, status::StatusPurpose::Display)?;
 
     let has_interesting_changes = result
         .statuses
         .iter()
-        .any(|c| c.status_type != status::StatusType::Unchanged);
+        .any(|c| c.status_type() != status::StatusType::Unchanged);
 
     if result.statuses.is_empty() {
         return Ok(ExitCode::SUCCESS);
@@ -166,6 +166,7 @@ fn handle_verify(path: PathBuf) -> anyhow::Result<ExitCode> {
         &path,
         ChecksumPolicy::Always,
         status::StatusMode::Interesting,
+        status::StatusPurpose::Display,
     )?;
 
     if result.statuses.is_empty() {
@@ -181,9 +182,9 @@ fn handle_verify(path: PathBuf) -> anyhow::Result<ExitCode> {
     );
 }
 
-fn print_statuses(statuses: &[status::Status]) {
-    for status in statuses {
-        let status_code = match status.status_type {
+fn print_statuses(statuses: &[status::StatusEntry]) {
+    for entry in statuses {
+        let status_code = match entry.status_type() {
             status::StatusType::Added => "A",
             status::StatusType::Removed => "R",
             status::StatusType::PossiblyModified => "M?",
@@ -191,7 +192,7 @@ fn print_statuses(statuses: &[status::Status]) {
             status::StatusType::Unchanged => ".",
         };
 
-        println!("{} {}", status_code, status.path.display());
+        println!("{} {}", status_code, entry.path().display());
     }
 }
 


### PR DESCRIPTION
This addresses a TODO from earlier. We're now not taking any action until at the very end after first preparing them in memory.

This means we can fingerprint after already haven determined intended actions, so `ward update` is no longer subject to incorrect behavior due to concurrent modification. At least not more incorrect than can be reasonably expected (written ward files will actually match the data observed by the process, and when fingerprint is given action is only taken if said data matches the fingerprint).