### PR TITLE
No longer allow dead code.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,4 +179,3 @@ When implementing recursive operations:
 
 - Do not add trivial inline comments (see AGENTS.md)
 - Only add comments for non-obvious logic or to explain "why" not "what"
-- Use `#[allow(dead_code)]` for items not yet wired into CLI

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -3,7 +3,6 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 pub enum ChecksumError {
     #[error("IO error: {0}")]
@@ -14,7 +13,6 @@ pub enum ChecksumError {
     ConcurrentModification(PathBuf),
 }
 
-#[allow(dead_code)]
 pub struct FileChecksum {
     /// Hex encoded.
     pub sha256: String,
@@ -38,7 +36,6 @@ pub struct FileChecksum {
 /// - `ChecksumError::ConcurrentModification`: File was detected as being modified while
 ///   checksumming. Note that the absence of this error is *not* a guarantee that the
 ///   file was *not* modified.
-#[allow(dead_code)]
 pub fn checksum_file(path: &Path) -> Result<FileChecksum, ChecksumError> {
     let metadata_before = std::fs::metadata(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::PermissionDenied {

--- a/src/dir_list.rs
+++ b/src/dir_list.rs
@@ -20,7 +20,6 @@ pub enum DirListError {
     PermissionDenied(PathBuf),
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FsEntry {
     File { mtime: SystemTime, size: u64 },
@@ -28,7 +27,6 @@ pub enum FsEntry {
     Symlink { symlink_target: PathBuf },
 }
 
-#[allow(dead_code)]
 pub fn list_directory(root: &Path) -> Result<BTreeMap<String, FsEntry>, DirListError> {
     let root = root.canonicalize().map_err(|e| {
         if e.kind() == std::io::ErrorKind::PermissionDenied {

--- a/src/status.rs
+++ b/src/status.rs
@@ -20,7 +20,6 @@ pub enum StatusError {
     Other(String),
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusType {
     Added,
@@ -70,7 +69,6 @@ pub enum StatusType {
 /// - `Unchanged`: Entry exists in both and matches. The `ward_entry` contains the
 ///   current entry data (if `WardUpdate` purpose), which may have updated metadata
 ///   even if content is unchanged.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StatusEntry {
     Added {
@@ -93,7 +91,6 @@ pub enum StatusEntry {
     },
 }
 
-#[allow(dead_code)]
 impl StatusEntry {
     pub fn path(&self) -> &Path {
         match self {
@@ -126,7 +123,6 @@ impl StatusEntry {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChecksumPolicy {
     /// Never compute checksums. Files with differing metadata will be
@@ -147,7 +143,6 @@ pub enum ChecksumPolicy {
 ///
 /// This is orthogonal to `ChecksumPolicy` - the policy controls *when* checksums
 /// are computed, while purpose controls *whether* to populate `ward_entry` fields.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusPurpose {
     /// Display status to user.
@@ -174,7 +169,6 @@ pub enum StatusPurpose {
     WardUpdate,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusMode {
     /// Only include files with interesting changes (added, removed, modified, possibly modified)
@@ -184,7 +178,6 @@ pub enum StatusMode {
     All,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusResult {
     pub statuses: Vec<StatusEntry>,
@@ -238,7 +231,6 @@ pub struct StatusResult {
 /// * Ward files are corrupted or have unsupported versions
 /// * Permission denied accessing files or directories
 /// * File modified during checksumming
-#[allow(dead_code)]
 pub fn compute_status(
     root: &Path,
     policy: ChecksumPolicy,
@@ -597,7 +589,6 @@ fn compute_fingerprint(statuses: &[StatusEntry]) -> String {
 /// # Errors
 ///
 /// Returns error if a path cannot be parsed or converted.
-#[allow(dead_code)]
 pub fn build_ward_files(
     root: &Path,
     status_result: &StatusResult,

--- a/src/update.rs
+++ b/src/update.rs
@@ -30,7 +30,6 @@ pub enum WardError {
     FingerprintMismatch { expected: String, actual: String },
 }
 
-#[allow(dead_code)]
 pub struct WardOptions {
     pub init: bool,
     pub allow_init: bool,
@@ -38,7 +37,6 @@ pub struct WardOptions {
     pub dry_run: bool,
 }
 
-#[allow(dead_code)]
 pub struct WardResult {
     pub files_warded: usize,
     pub ward_files_updated: Vec<PathBuf>,
@@ -89,7 +87,6 @@ pub struct WardResult {
 /// * `files_warded` - Number of files that were added or had content changes (excludes files
 ///   that were checksummed but found to be unchanged, and excludes directories/symlinks)
 /// * `ward_files_updated` - Relative paths of `.treeward` files that were written
-#[allow(dead_code)]
 pub fn ward_directory(root: &Path, options: WardOptions) -> Result<WardResult, WardError> {
     let root = root.canonicalize().map_err(|e| {
         if e.kind() == ErrorKind::PermissionDenied {

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -16,7 +16,6 @@ pub enum WardFileError {
     UnsupportedVersion(u32),
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", deny_unknown_fields)]
 pub enum WardEntry {
@@ -34,7 +33,6 @@ pub enum WardEntry {
     Symlink { symlink_target: PathBuf },
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Metadata {
@@ -50,7 +48,6 @@ struct MetadataOnly {
     metadata: Metadata,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WardFile {
@@ -58,7 +55,6 @@ pub struct WardFile {
     pub entries: BTreeMap<String, WardEntry>,
 }
 
-#[allow(dead_code)]
 impl WardFile {
     const SUPPORTED_VERSION: u32 = 1;
 


### PR DESCRIPTION
Dead code annotations were needed early on before we had wired up functionality to the main function - now we can remove all of them.