### PR TITLE
Improve sha256 perf by enabling asm feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +244,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "float-cmp"
@@ -531,6 +547,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -541,6 +567,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/treeward"
 
 [dependencies]
-sha2 = "0.10"
+# The "asm" feature improves sha256 performance on a 2023 macbook pro
+# by ~ 5x (and is then roughly equal in speed to the sha256 cmdline
+# tool Apple provides).
+sha2 = { version = "0.10", features = ["asm"] }
 clap = { version = "4.5.53", features = ["derive"] }
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This enables handcrafted assembly that takes advantage of hardware acceleration. As noted in the Cargo.toml comment, this improves performance by 5x on my 2023 macbook pro and gets us to the same performance as the sha256 tool provided by Apple.