### PR TITLE
Make init+update consistent with status w.r.t. checksums, fix bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +332,17 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -456,6 +478,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -755,6 +786,7 @@ dependencies = [
  "assert_cmd",
  "base64",
  "clap",
+ "filetime",
  "nix",
  "predicates",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tempfile = "3.13"
 assert_cmd = "2.0"
 predicates = "3.1"
 nix = { version = "0.29", features = ["fs"] }
+filetime = "0.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,13 +271,23 @@ EXAMPLES:
         #[arg(long)]
         allow_init: bool,
 
-        /// Only proceed if changes match this fingerprint from status
+        /// Only proceed if changes match this fingerprint from status.
+        /// When using this flag, ensure --verify/--always-verify flags match
+        /// those used with the status command that produced the fingerprint.
         #[arg(long, value_name = "FINGERPRINT")]
         fingerprint: Option<String>,
 
         /// Preview changes without writing ward files
         #[arg(long)]
         dry_run: bool,
+
+        /// Verify checksums for files whose metadata changed
+        #[arg(long)]
+        verify: bool,
+
+        /// Always verify checksums for all files
+        #[arg(long, conflicts_with = "verify")]
+        always_verify: bool,
     },
 
     /// Initialize ward files in a directory
@@ -390,13 +400,23 @@ EXAMPLES:
   $ treeward update
 ")]
     Init {
-        /// Only proceed if changes match this fingerprint from status
+        /// Only proceed if changes match this fingerprint from status.
+        /// When using this flag, ensure --verify/--always-verify flags match
+        /// those used with the status command that produced the fingerprint.
         #[arg(long, value_name = "FINGERPRINT")]
         fingerprint: Option<String>,
 
         /// Preview changes without writing ward files
         #[arg(long)]
         dry_run: bool,
+
+        /// Verify checksums for files whose metadata changed
+        #[arg(long)]
+        verify: bool,
+
+        /// Always verify checksums for all files
+        #[arg(long, conflicts_with = "verify")]
+        always_verify: bool,
     },
 
     /// Show status of files (added, removed, modified)


### PR DESCRIPTION
Add --verify/--always-verify flags to update and init commands

Previously, `update` always checksummed files with changed metadata
internally, while `status` defaults to metadata-only comparison. This
caused fingerprint mismatches when a file's mtime changed but content
stayed the same: `status` reported M? but `update` found it unchanged
and omitted it from its fingerprint.

Now both commands accept the same verification flags, and fingerprints
are computed based on the policy rather than the internal checksumming
behavior. When using --fingerprint, users must use matching flags.