### PR TITLE
Fix CI/CD example order

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ fi
 ```yaml
 - name: Verify build artifacts
   run: |
-    treeward -C ./dist init
     # ... build process ...
+    treeward -C ./dist update --allow-init
     treeward -C ./dist verify
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,8 +98,8 @@ COMMON USE CASES:
     $ treeward -C /data verify || alert_admin
 
   CI/CD artifact verification:
-    $ treeward -C ./dist init
     $ # ... build process ...
+    $ treeward -C ./dist update --allow-init
     $ treeward -C ./dist verify
 
   Idempotent scripting:


### PR DESCRIPTION
Move warding after the build so verify checks built artifacts (use update --allow-init).