### PR TITLE
fix: fingerprint new file contents when verifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,9 @@ files.
 
 ### Fingerprinting in depth
 
-Fingerprints are SHA-256 hashes computed from the list of changes (path + status type). They serve two purposes:
+Fingerprints are SHA-256 hashes computed from the list of changes plus enough entry-specific data to identify what was
+reviewed. Every changed entry contributes its path and status type. Files also contribute mtime and size, and
+checksum-based policies include SHA-256 payloads for files that are checksummed as part of status.
 
 1. **TOCTOU protection** - Ensure the changes you reviewed are exactly what gets applied
 2. **Idempotency check** - Detect when the filesystem has drifted from what you expected
@@ -339,9 +341,11 @@ Fingerprints are SHA-256 hashes computed from the list of changes (path + status
 The `status` and `update`/`init` commands support the same verification flags:
 
 - Default (no flag): Only compare metadata (mtime/size). Files with changed metadata show as `M?` (PossiblyModified).
-- `--verify`: Checksum files whose metadata differs. Confirms whether content actually changed (`M`) or just metadata
-  (`M?` upgrades to clean if unchanged).
-- `--always-verify`: Checksum all files regardless of metadata. Detects silent corruption.
+- `--verify`: Checksum files whose metadata differs, plus new files and file replacements that need checksum-backed
+  fingerprint payloads. Confirms whether content actually changed (`M`) or just metadata (`M?` upgrades to clean if
+  unchanged).
+- `--always-verify`: Checksum all files regardless of metadata. New files and file replacements also carry checksum
+  payloads in fingerprints. Detects silent corruption.
 
 When using `--fingerprint`, you must use the same verification flags with both commands:
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -476,13 +476,19 @@ fn compare_entries(
         if !ward_entries.contains_key(name) {
             let relative_path = make_relative_path(tree_root, current_dir, name)?;
             let fs_entry = &fs_entries[name];
-            let fingerprint_payload = fingerprint_payload_from_fs_entry(fs_entry, None)?;
 
             let ward_entry = if purpose == StatusPurpose::WardUpdate {
                 Some(build_ward_entry_from_fs(current_dir, name, fs_entry)?)
             } else {
                 None
             };
+            let fingerprint_payload = current_entry_fingerprint_payload(
+                current_dir,
+                name,
+                fs_entry,
+                ward_entry.as_ref(),
+                policy,
+            )?;
 
             statuses.push(StatusEntry::Added {
                 path: relative_path.clone(),
@@ -742,7 +748,13 @@ fn check_modification(
             } else {
                 None
             };
-            let fingerprint_payload = fingerprint_payload_from_fs_entry(fs_entry, None)?;
+            let fingerprint_payload = current_entry_fingerprint_payload(
+                current_dir,
+                name,
+                fs_entry,
+                new_ward_entry.as_ref(),
+                policy,
+            )?;
             statuses.push(StatusEntry::Modified {
                 path: relative_path.clone(),
                 ward_entry: new_ward_entry,
@@ -787,6 +799,37 @@ fn make_relative_path(
     let relative_dir = current_dir.strip_prefix(tree_root)?;
     let relative_path = relative_dir.join(name);
     path_to_str(&relative_path).map(|s| s.to_string())
+}
+
+/// Builds fingerprint material for a filesystem-side entry with no comparable file ward state.
+///
+/// Added entries and type changes are already interesting without a checksum, but
+/// checksum-based policies still need file content in the fingerprint. Otherwise
+/// a file could be reviewed under `--verify` or `--always-verify`, changed while
+/// preserving size and mtime, and then accepted by `update --fingerprint`.
+fn current_entry_fingerprint_payload(
+    current_dir: &Path,
+    name: &str,
+    fs_entry: &FsEntry,
+    ward_entry: Option<&WardEntry>,
+    policy: ChecksumPolicy,
+) -> Result<FingerprintPayload, StatusError> {
+    let file_sha256 = if policy != ChecksumPolicy::Never {
+        match (fs_entry, ward_entry) {
+            (
+                FsEntry::File { .. },
+                Some(WardEntry::File {
+                    sha256: ward_sha, ..
+                }),
+            ) => Some(ward_sha.clone()),
+            (FsEntry::File { .. }, _) => Some(checksum_file(&current_dir.join(name))?.sha256),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    fingerprint_payload_from_fs_entry(fs_entry, file_sha256)
 }
 
 fn fingerprint_payload_from_fs_entry(

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -254,6 +254,76 @@ fn update_fingerprint_rejects_second_edit_of_already_modified_file() {
         .stderr(predicate::str::contains("Fingerprint mismatch"));
 }
 
+#[test]
+fn update_always_verify_rejects_second_edit_of_added_file_with_preserved_metadata() {
+    update_rejects_second_edit_of_added_file_with_preserved_metadata(&["--always-verify"]);
+}
+
+#[test]
+fn update_verify_rejects_second_edit_of_added_file_with_preserved_metadata() {
+    update_rejects_second_edit_of_added_file_with_preserved_metadata(&["--verify"]);
+}
+
+fn update_rejects_second_edit_of_added_file_with_preserved_metadata(verify_args: &[&str]) {
+    let temp = TempDir::new().unwrap();
+
+    treeward_cmd(temp.path()).arg("init").assert().success();
+
+    let file_path = temp.path().join("added.txt");
+    fs::write(&file_path, "aaaaa").unwrap();
+    set_file_mtime(&file_path, FileTime::from_unix_time(1_000_000_000, 0)).unwrap();
+
+    let (_, fingerprint) = status_fingerprint(temp.path(), verify_args);
+
+    fs::write(&file_path, "bbbbb").unwrap();
+    set_file_mtime(&file_path, FileTime::from_unix_time(1_000_000_000, 0)).unwrap();
+
+    treeward_cmd(temp.path())
+        .arg("update")
+        .args(verify_args)
+        .arg("--fingerprint")
+        .arg(&fingerprint)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Fingerprint mismatch"));
+}
+
+#[test]
+fn update_always_verify_rejects_second_edit_of_type_changed_file_with_preserved_metadata() {
+    update_rejects_second_edit_of_type_changed_file_with_preserved_metadata(&["--always-verify"]);
+}
+
+#[test]
+fn update_verify_rejects_second_edit_of_type_changed_file_with_preserved_metadata() {
+    update_rejects_second_edit_of_type_changed_file_with_preserved_metadata(&["--verify"]);
+}
+
+fn update_rejects_second_edit_of_type_changed_file_with_preserved_metadata(verify_args: &[&str]) {
+    let temp = TempDir::new().unwrap();
+    let changed_path = temp.path().join("entry");
+    fs::create_dir(&changed_path).unwrap();
+
+    treeward_cmd(temp.path()).arg("init").assert().success();
+
+    fs::remove_dir_all(&changed_path).unwrap();
+    fs::write(&changed_path, "aaaaa").unwrap();
+    set_file_mtime(&changed_path, FileTime::from_unix_time(1_000_000_000, 0)).unwrap();
+
+    let (_, fingerprint) = status_fingerprint(temp.path(), verify_args);
+
+    fs::write(&changed_path, "bbbbb").unwrap();
+    set_file_mtime(&changed_path, FileTime::from_unix_time(1_000_000_000, 0)).unwrap();
+
+    treeward_cmd(temp.path())
+        .arg("update")
+        .args(verify_args)
+        .arg("--fingerprint")
+        .arg(&fingerprint)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Fingerprint mismatch"));
+}
+
 /// Tests that mismatched verification flags cause fingerprint mismatch when
 /// metadata changes but content stays the same.
 #[test]


### PR DESCRIPTION
Checksum-based status policies need to bind reviewed new files and file replacements to their contents, not only to size and mtime. Otherwise a reviewed change can be swapped for different same-shaped content before update.

changelog: include
