### PR TITLE
fix: canonicalize recursive operation roots

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -323,7 +323,9 @@ pub fn compute_status(
     purpose: StatusPurpose,
     diff_mode: DiffMode,
 ) -> Result<StatusResult, StatusError> {
-    let root = root.to_path_buf();
+    let root = root
+        .canonicalize()
+        .map_err(|e| StatusError::DirList(DirListError::Io(e)))?;
 
     let mut statuses = Vec::new();
     let mut fingerprint_records = Vec::new();

--- a/src/status/tests/unix.rs
+++ b/src/status/tests/unix.rs
@@ -2,6 +2,33 @@ use super::*;
 
 #[test]
 #[cfg(unix)]
+fn test_status_accepts_symlinked_root() {
+    let temp = TempDir::new().unwrap();
+    let real_root = temp.path().join("real");
+    let linked_root = temp.path().join("linked");
+    fs::create_dir(&real_root).unwrap();
+    unix::fs::symlink(&real_root, &linked_root).unwrap();
+
+    create_ward_file(&real_root, BTreeMap::new());
+    fs::create_dir(real_root.join("dir")).unwrap();
+    fs::write(real_root.join("dir/file.txt"), "content").unwrap();
+
+    let result = compute_status(
+        &linked_root,
+        ChecksumPolicy::Never,
+        StatusMode::Interesting,
+        StatusPurpose::Display,
+        DiffMode::None,
+    )
+    .unwrap();
+
+    let paths: Vec<_> = result.statuses.iter().map(|status| status.path()).collect();
+    assert!(paths.contains(&"dir"));
+    assert!(paths.contains(&"dir/file.txt"));
+}
+
+#[test]
+#[cfg(unix)]
 fn test_symlink_target_changed() {
     let temp = TempDir::new().unwrap();
     let root = temp.path();

--- a/src/update.rs
+++ b/src/update.rs
@@ -99,7 +99,7 @@ pub struct WardResult {
 /// * `ward_files_updated` - Relative paths of `.treeward` files that were written (or
 ///   would be written in dry-run mode)
 pub fn ward_directory(root: &Path, options: WardOptions) -> Result<WardResult, WardError> {
-    let root = root.to_path_buf();
+    let root = root.canonicalize().map_err(DirListError::Io)?;
 
     let ward_path = root.join(".treeward");
 
@@ -215,6 +215,42 @@ mod tests {
 
         let dir1_ward = WardFile::load(&root.join("dir1/.treeward")).unwrap();
         assert!(dir1_ward.entries.contains_key("file2.txt"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_ward_directory_accepts_symlinked_root() {
+        let temp = TempDir::new().unwrap();
+        let real_root = temp.path().join("real");
+        let linked_root = temp.path().join("linked");
+        fs::create_dir(&real_root).unwrap();
+        unix::fs::symlink(&real_root, &linked_root).unwrap();
+
+        fs::create_dir(real_root.join("dir")).unwrap();
+        fs::write(real_root.join("dir/file.txt"), "content").unwrap();
+
+        let options = WardOptions {
+            init: true,
+            allow_init: false,
+            fingerprint: None,
+            dry_run: false,
+            checksum_policy: ChecksumPolicy::Never,
+        };
+
+        let result = ward_directory(&linked_root, options).unwrap();
+
+        assert!(
+            result
+                .ward_files_updated
+                .contains(&PathBuf::from(".treeward"))
+        );
+        assert!(
+            result
+                .ward_files_updated
+                .contains(&PathBuf::from("dir/.treeward"))
+        );
+        assert!(real_root.join(".treeward").exists());
+        assert!(real_root.join("dir/.treeward").exists());
     }
 
     #[test]


### PR DESCRIPTION
Recursive operations already document canonical root handling. Doing that at the operation boundary keeps traversal and ward-write path math anchored to one normalized root.

changelog: include
