### PR TITLE
docs: clarify status fingerprint output

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ R  oldfile.txt
 
 **Fingerprints:**
 
-Every status check produces a unique fingerprint representing the exact changeset. Use it with `init --fingerprint` or
-`update --fingerprint` to ensure you're applying exactly the changes you reviewed:
+When `status` finds changes, it prints a fingerprint representing the exact changeset. Use it with `init --fingerprint`
+or `update --fingerprint` to ensure you're applying exactly the changes you reviewed:
 
 ```bash
 treeward status > review.txt

--- a/src/cli/help_text.rs
+++ b/src/cli/help_text.rs
@@ -448,7 +448,7 @@ The --diff flag implies --verify, since showing sha256 differences requires chec
 
 FINGERPRINTS:
 
-Every status check produces a unique fingerprint representing the exact changeset:
+When status finds changes, it produces a unique fingerprint representing the exact changeset:
 
   Fingerprint: abc123def456...
 


### PR DESCRIPTION
Clean status output intentionally has no fingerprint because there is no changeset to accept. The docs should describe the output users actually see.

changelog: skip
