### PR TITLE
test: strengthen ward behavior assertions

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -208,7 +208,10 @@ mod tests {
 
         let result = checksum_file(temp_file.path()).unwrap();
 
-        assert_eq!(result.sha256.len(), 64);
+        assert_eq!(
+            result.sha256,
+            "4e29ad18ab9f42d7c233500771a39d7c852b200baf328fd00fbbe3fecea1eb56"
+        );
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -293,7 +293,6 @@ mod tests {
         };
 
         ward_directory(root, init_options).unwrap();
-
         fs::write(root.join("file2.txt"), "content2").unwrap();
 
         let update_options = WardOptions {
@@ -327,7 +326,6 @@ mod tests {
         };
 
         ward_directory(root, init_options).unwrap();
-
         fs::write(root.join("file2.txt"), "content2").unwrap();
 
         // Both status and update must use the same checksum policy for
@@ -436,6 +434,8 @@ mod tests {
         };
 
         ward_directory(root, init_options).unwrap();
+        let ward_path = root.join(".treeward");
+        let ward_before = fs::read_to_string(&ward_path).unwrap();
 
         fs::write(root.join("file2.txt"), "content2").unwrap();
 
@@ -458,7 +458,15 @@ mod tests {
             _ => panic!("Expected FingerprintMismatch error"),
         }
 
-        assert!(!root.join("file2.txt").join(".treeward").exists());
+        let ward_after = fs::read_to_string(&ward_path).unwrap();
+        assert_eq!(
+            ward_before, ward_after,
+            "fingerprint mismatch must not rewrite the existing ward file"
+        );
+        assert!(
+            !ward_after.contains("file2.txt"),
+            "failed update must not accept the new file into the ward"
+        );
     }
 
     /// Tests TOCTOU protection: if a new file appears between `status` and `update`,

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -239,7 +239,7 @@ type = "dir"
         assert_eq!(ward_file.entries.len(), 1);
 
         let entry = ward_file.entries.get("dir1").unwrap();
-        matches!(entry, WardEntry::Dir {});
+        assert!(matches!(entry, WardEntry::Dir {}));
     }
 
     #[test]
@@ -365,6 +365,7 @@ sha256 = "should_be_rejected"
         let toml_string = ward_file.to_toml().unwrap();
         let parsed = WardFile::from_toml(&toml_string).unwrap();
 
+        assert_eq!(parsed.entries, ward_file.entries);
         assert_eq!(parsed.entries.len(), 2);
         assert!(parsed.entries.contains_key("file1.txt"));
         assert!(parsed.entries.contains_key("dir1"));


### PR DESCRIPTION
These tests were meant to protect parser round trips, fingerprint write rejection, and large-file hashing. Stronger assertions make those tests fail when the intended behavior breaks.

changelog: skip
