### PR TITLE
docs: align validation commands with CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,9 @@ treeward update  # Always succeeds, no fingerprint check
 
 Standard Rust idioms apply:
 
-- `cargo test`
+- `cargo test --locked --all-features --all-targets`
 - `cargo fmt`
-- `cargo clippy -- -D warnings`
+- `cargo clippy --all-targets --all-features -- -D warnings`
 
 ## License
 


### PR DESCRIPTION
The README should not point contributors at a narrower check set than CI uses. Matching target and feature coverage reduces local-green, CI-red surprises.

changelog: skip
