### PR TITLE
refactor: simplify status and diff plumbing

### DIFF
--- a/src/diffing.rs
+++ b/src/diffing.rs
@@ -56,19 +56,7 @@ fn format_diff_lines(entry: &status::StatusEntry) -> Vec<String> {
 }
 
 fn format_was_entry(entry: &WardEntry) -> String {
-    match entry {
-        WardEntry::File { sha256, size, .. } => {
-            format!(
-                "   was: file ({}, sha256: {})",
-                format_size(*size),
-                truncate_sha256(sha256)
-            )
-        }
-        WardEntry::Dir {} => "   was: directory".to_string(),
-        WardEntry::Symlink { symlink_target } => {
-            format!("   was: symlink -> {}", symlink_target.display())
-        }
-    }
+    format!("   was: {}", format_entry_type(entry))
 }
 
 fn format_was_entry_verbose(entry: &WardEntry) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn main() -> ExitCode {
             verify,
             always_verify,
         } => handle_init_or_update(
-            current_dir.clone(),
+            current_dir,
             false,
             allow_init,
             fingerprint,
@@ -102,7 +102,7 @@ fn main() -> ExitCode {
             verify,
             always_verify,
         } => handle_init_or_update(
-            current_dir.clone(),
+            current_dir,
             true,
             false,
             fingerprint,
@@ -115,7 +115,7 @@ fn main() -> ExitCode {
             always_verify,
             all,
             diff,
-        } => handle_status(current_dir.clone(), verify, always_verify, all, diff),
+        } => handle_status(current_dir, verify, always_verify, all, diff),
         Command::Verify {} => handle_verify(current_dir),
     };
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -372,7 +372,7 @@ fn walk_directory(
 
     let ward_path = current_dir.join(".treeward");
     let ward_file = WardFile::load_if_exists(&ward_path)?;
-    let ward_entries = ward_file.map(|wf| wf.entries).unwrap_or_else(BTreeMap::new);
+    let ward_entries = ward_file.map(|wf| wf.entries).unwrap_or_default();
 
     let fs_entries = match list_directory(current_dir) {
         Ok(entries) => entries,
@@ -474,10 +474,9 @@ fn compare_entries(
     purpose: StatusPurpose,
     diff_mode: DiffMode,
 ) -> Result<(), StatusError> {
-    for name in fs_entries.keys() {
+    for (name, fs_entry) in fs_entries {
         if !ward_entries.contains_key(name) {
             let relative_path = make_relative_path(tree_root, current_dir, name)?;
-            let fs_entry = &fs_entries[name];
 
             let ward_entry = if purpose == StatusPurpose::WardUpdate {
                 Some(build_ward_entry_from_fs(current_dir, name, fs_entry)?)
@@ -504,10 +503,9 @@ fn compare_entries(
         }
     }
 
-    for name in ward_entries.keys() {
+    for (name, removed_ward_entry) in ward_entries {
         if !fs_entries.contains_key(name) {
             let relative_path = make_relative_path(tree_root, current_dir, name)?;
-            let removed_ward_entry = ward_entries[name].clone();
             let old_ward_entry = if diff_mode == DiffMode::Capture {
                 Some(removed_ward_entry.clone())
             } else {
@@ -521,7 +519,7 @@ fn compare_entries(
                 path: relative_path,
                 status_type: StatusType::Removed,
                 payload: FingerprintPayload::Removed {
-                    ward_entry: removed_ward_entry,
+                    ward_entry: removed_ward_entry.clone(),
                 },
             });
         }
@@ -985,7 +983,7 @@ pub fn build_ward_files(
                     .to_string();
 
                 dir_entries
-                    .entry(parent_dir.clone())
+                    .entry(parent_dir)
                     .or_default()
                     .insert(filename, ward_entry.clone());
 


### PR DESCRIPTION
This removes a few redundant clones, lookups, and duplicated formatting branches in code that is easier to read when it follows the data flow directly.

changelog: skip
