### PR TITLE
docs: bootstrap SPEC.md for user-observable behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 Guidance for agents editing this repository.
 
+## Behavior Specification (SPEC.md)
+
+`SPEC.md` at the repo root specifies user-observable behavior (command output, exit codes, on-disk formats). It is the
+contract the implementation must satisfy.
+
+- When intentionally changing user-observable behavior, update `SPEC.md` in the same change.
+- Otherwise, conform to `SPEC.md`. When implementation and spec disagree, the implementation is wrong unless the spec
+  itself is shown to be — fix the code, not the spec.
+- Keep implementation details out of the spec; it describes what a user can observe, not how it is achieved.
+
 ## Style And Intent
 
 - Place Rust doc comments (`///` and `//!`) before attribute directives such as `#[derive(...)]`, `#[cfg(...)]`, and

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,14 @@
+# SPEC
+
+This file specifies treeward's user-observable behavior: command output, exit codes, and on-disk formats. It does not
+describe implementation choices — those belong in code and doc comments.
+
+The spec is the contract. When behavior is intentionally changed, the change and the spec update land together.
+Otherwise, the implementation conforms to what is written here; divergence is an implementation bug.
+
+NOTE: This spec is bootstrapped empty and populated incrementally as behavior is intentionally introduced or changed.
+Absence of an entry means the behavior is not yet specified, not that it is unspecified by design.
+
+## Behaviors
+
+(none yet)


### PR DESCRIPTION
Transitions the project to a SPEC-based workflow: SPEC.md at the repo root will hold user-observable behavior specifications (not implementation choices), and agent guidance now requires updating the spec whenever behavior is intentionally changed and conforming to it otherwise. The spec starts empty so this PR is purely the transition; entries get added by the changes that introduce or alter behavior.

changelog: skip
