### PR TITLE
test: close coverage gaps in verify, diff, and fingerprint behavior

### DIFF
--- a/src/status/tests/mode_and_fingerprint.rs
+++ b/src/status/tests/mode_and_fingerprint.rs
@@ -245,6 +245,106 @@ fn test_unchanged_not_in_fingerprint() {
     assert_eq!(result_interesting.fingerprint, result_all.fingerprint);
 }
 
+/// A Removed entry must bind the fingerprint to the prior ward state, not just
+/// path + "R".
+///
+/// `FingerprintPayload::Removed` exists so ward-state drift between status and
+/// update cannot hide behind an unchanged-looking `R` entry: if the recorded
+/// ward data for the removed path changes, the fingerprint must change too,
+/// even though path and status class are identical.
+#[test]
+fn test_removed_fingerprint_bound_to_prior_ward_state() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    let fingerprint_for_recorded_sha = |sha: &str| {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "removed.txt".to_string(),
+            WardEntry::File {
+                sha256: sha.to_string(),
+                mtime_nanos: 1000,
+                size: 5,
+            },
+        );
+        create_ward_file(root, entries);
+
+        let result = compute_status(
+            root,
+            ChecksumPolicy::Never,
+            StatusMode::Interesting,
+            StatusPurpose::Display,
+            DiffMode::None,
+        )
+        .unwrap();
+
+        assert_eq!(result.statuses.len(), 1);
+        assert_eq!(result.statuses[0].status_type(), StatusType::Removed);
+        assert_eq!(result.statuses[0].path(), "removed.txt");
+        result.fingerprint
+    };
+
+    let fingerprint1 = fingerprint_for_recorded_sha("aaa");
+    let fingerprint2 = fingerprint_for_recorded_sha("bbb");
+
+    assert_ne!(
+        fingerprint1, fingerprint2,
+        "fingerprint must reflect the removed entry's prior ward state"
+    );
+}
+
+#[test]
+fn test_mtime_to_nanos_rejects_pre_epoch() {
+    let pre_epoch = UNIX_EPOCH - std::time::Duration::from_secs(1);
+    let err = mtime_to_nanos(&pre_epoch).unwrap_err();
+    assert!(
+        err.to_string().contains("before UNIX epoch"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_mtime_to_nanos_rejects_u64_overflow() {
+    // Just past u64::MAX nanoseconds (~year 2554), but still well within what
+    // SystemTime can represent on all supported platforms.
+    let far_future = UNIX_EPOCH + std::time::Duration::from_secs(18_446_744_074);
+    let err = mtime_to_nanos(&far_future).unwrap_err();
+    assert!(
+        err.to_string().contains("overflow"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+/// A real file with a pre-epoch mtime must surface the conversion error through
+/// `compute_status` rather than being silently skipped or misreported.
+#[test]
+fn test_status_errors_on_pre_epoch_mtime() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    create_ward_file(root, BTreeMap::new());
+    fs::write(root.join("old.txt"), "content").unwrap();
+    set_file_mtime(root.join("old.txt"), FileTime::from_unix_time(-1, 0)).unwrap();
+
+    let err = compute_status(
+        root,
+        ChecksumPolicy::Never,
+        StatusMode::Interesting,
+        StatusPurpose::Display,
+        DiffMode::None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("before UNIX epoch"),
+        "unexpected error: {}",
+        err
+    );
+}
+
 /// WARNING: This test verifies that non-UTF-8 paths are rejected rather than
 /// silently converted. Do not change this behavior without extreme care!
 ///

--- a/src/status/tests/policy.rs
+++ b/src/status/tests/policy.rs
@@ -144,6 +144,122 @@ fn test_checksum_policy_always_with_corruption() {
     assert_eq!(result.statuses[0].status_type(), StatusType::Modified);
 }
 
+/// Diff capture must populate `old_ward_entry` when ONLY the checksum differs.
+///
+/// With matching metadata, `metadata_differs` is false and the capture condition
+/// rests entirely on its `sha256_differs` half — the path that lets
+/// `--diff --always-verify` display what silent corruption changed. Without this
+/// test, that half of the condition could be deleted with no test failing.
+#[test]
+fn test_diff_capture_on_checksum_only_difference() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    fs::write(root.join("file1.txt"), "content").unwrap();
+    let actual_checksum = checksum_file(&root.join("file1.txt")).unwrap();
+
+    let recorded_entry = WardEntry::File {
+        sha256: "wrong_checksum_simulating_corruption".to_string(),
+        mtime_nanos: mtime_to_nanos(&actual_checksum.mtime).unwrap(),
+        size: actual_checksum.size,
+    };
+    let mut entries = BTreeMap::new();
+    entries.insert("file1.txt".to_string(), recorded_entry.clone());
+    create_ward_file(root, entries);
+
+    let result = compute_status(
+        root,
+        ChecksumPolicy::Always,
+        StatusMode::Interesting,
+        StatusPurpose::Display,
+        DiffMode::Capture,
+    )
+    .unwrap();
+
+    assert_eq!(result.statuses.len(), 1);
+    match &result.statuses[0] {
+        StatusEntry::Modified {
+            path,
+            ward_entry,
+            old_ward_entry,
+        } => {
+            assert_eq!(path, "file1.txt");
+            assert_eq!(
+                old_ward_entry.as_ref(),
+                Some(&recorded_entry),
+                "old ward entry must be captured for diff display"
+            );
+            match ward_entry {
+                Some(WardEntry::File { sha256, .. }) => {
+                    assert_eq!(sha256, &actual_checksum.sha256);
+                }
+                other => panic!("Expected new file ward entry, got {:?}", other),
+            }
+        }
+        other => panic!("Expected Modified entry, got {:?}", other),
+    }
+}
+
+/// `DiffMode::Capture` must force checksumming of metadata-differing files even
+/// under `ChecksumPolicy::Never`.
+///
+/// The status class stays PossiblyModified — policy alone controls reporting —
+/// but the captured `ward_entry` must carry the file's real current checksum so
+/// the diff can show old vs new. If the diff-driven checksum term were dropped,
+/// the entry would silently carry the stale recorded checksum instead.
+#[test]
+fn test_diff_capture_forces_checksum_under_policy_never() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    fs::write(root.join("file1.txt"), "original content").unwrap();
+    let old_checksum = checksum_file(&root.join("file1.txt")).unwrap();
+
+    let recorded_entry = WardEntry::File {
+        sha256: old_checksum.sha256.clone(),
+        // Stale mtime so the entry is metadata-differing.
+        mtime_nanos: 1000,
+        size: old_checksum.size,
+    };
+    let mut entries = BTreeMap::new();
+    entries.insert("file1.txt".to_string(), recorded_entry.clone());
+    create_ward_file(root, entries);
+
+    fs::write(root.join("file1.txt"), "modified content").unwrap();
+    let new_checksum = checksum_file(&root.join("file1.txt")).unwrap();
+
+    let result = compute_status(
+        root,
+        ChecksumPolicy::Never,
+        StatusMode::Interesting,
+        StatusPurpose::Display,
+        DiffMode::Capture,
+    )
+    .unwrap();
+
+    assert_eq!(result.statuses.len(), 1);
+    match &result.statuses[0] {
+        StatusEntry::PossiblyModified {
+            path,
+            ward_entry,
+            old_ward_entry,
+        } => {
+            assert_eq!(path, "file1.txt");
+            assert_eq!(old_ward_entry.as_ref(), Some(&recorded_entry));
+            match ward_entry {
+                Some(WardEntry::File { sha256, .. }) => {
+                    assert_eq!(
+                        sha256, &new_checksum.sha256,
+                        "Capture must have checksummed the current content"
+                    );
+                }
+                other => panic!("Expected new file ward entry, got {:?}", other),
+            }
+        }
+        other => panic!("Expected PossiblyModified entry, got {:?}", other),
+    }
+}
+
 #[test]
 fn test_checksum_policy_always_without_corruption() {
     let temp = TempDir::new().unwrap();

--- a/src/update.rs
+++ b/src/update.rs
@@ -733,6 +733,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_complex_directory_tree() {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
@@ -873,6 +874,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_ward_write_permission_denied() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -908,6 +910,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_ward_write_permission_denied_subdirectory() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -860,6 +860,7 @@ unknown_field = "should_be_rejected"
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_save_permission_denied() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::TempDir;

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -2,6 +2,7 @@ mod common;
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use common::{status_output, treeward_cmd};
+use filetime::{FileTime, set_file_mtime};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
@@ -151,6 +152,46 @@ fn status_escapes_control_characters_in_file_names() {
         .failure()
         .stdout(predicate::str::contains(r"A  evil\u{1b}]0;pwned\u{7}.txt"))
         .stdout(predicate::str::contains("\x1b").not());
+}
+
+/// The distinguishing behavior of --always-verify is catching content changes
+/// when metadata is unchanged. The same-size write plus mtime restore makes the
+/// file invisible to both the default policy and --verify (which only checksums
+/// on metadata mismatch), so only Always-policy wiring can report it.
+#[test]
+fn status_always_verify_detects_content_change_with_unchanged_metadata() {
+    let temp = TempDir::new().unwrap();
+    let file_path = temp.path().join("file.txt");
+    fs::write(&file_path, "hello").unwrap();
+
+    treeward_cmd(temp.path()).arg("init").assert().success();
+
+    let original_mtime =
+        FileTime::from_system_time(fs::metadata(&file_path).unwrap().modified().unwrap());
+    fs::write(&file_path, "olleh").unwrap();
+    set_file_mtime(&file_path, original_mtime).unwrap();
+
+    // Both weaker policies must see a clean tree; this is what makes the
+    // --always-verify assertion below meaningful.
+    treeward_cmd(temp.path())
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+    treeward_cmd(temp.path())
+        .arg("status")
+        .arg("--verify")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    treeward_cmd(temp.path())
+        .arg("status")
+        .arg("--always-verify")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("M  file.txt"))
+        .stderr(predicate::str::is_empty());
 }
 
 #[test]
@@ -466,9 +507,9 @@ fn status_diff_all_no_details_for_unchanged() {
         let next_line = lines[unchanged_idx + 1];
         // Next line should be another status entry or empty/Fingerprint, not indented diff
         assert!(
-            !next_line.starts_with("   ")
-                || next_line.contains("size:") && !lines[unchanged_idx].contains("unchanged"),
-            "Unchanged file should not have diff details"
+            !next_line.starts_with("   "),
+            "Unchanged file should not have diff details, but found: {}",
+            next_line
         );
     }
 }

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,4 +1,5 @@
 use assert_cmd::cargo::cargo_bin_cmd;
+use filetime::{FileTime, set_file_mtime};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
@@ -62,6 +63,49 @@ fn verify_fails_on_modified_file() {
         .success();
 
     fs::write(&file_path, "changed").unwrap();
+
+    cargo_bin_cmd!("treeward")
+        .arg("-C")
+        .arg(temp.path())
+        .arg("verify")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("M  file.txt"))
+        .stderr(predicate::str::contains("Verification failed"));
+}
+
+/// The distinguishing behavior of `verify` is catching content changes when
+/// metadata is unchanged — anything weaker than ChecksumPolicy::Always in the
+/// CLI wiring would pass every metadata-changing test while silently losing
+/// this guarantee. The same-size write plus mtime restore makes the file look
+/// untouched to metadata-only comparison.
+#[test]
+fn verify_detects_content_change_with_unchanged_metadata() {
+    let temp = TempDir::new().unwrap();
+    let file_path = temp.path().join("file.txt");
+    fs::write(&file_path, "hello").unwrap();
+
+    cargo_bin_cmd!("treeward")
+        .arg("-C")
+        .arg(temp.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    let original_mtime =
+        FileTime::from_system_time(fs::metadata(&file_path).unwrap().modified().unwrap());
+    fs::write(&file_path, "olleh").unwrap();
+    set_file_mtime(&file_path, original_mtime).unwrap();
+
+    // Sanity-check the premise: metadata-only status must see a clean tree,
+    // otherwise this test is not exercising the checksum path at all.
+    cargo_bin_cmd!("treeward")
+        .arg("-C")
+        .arg(temp.path())
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
 
     cargo_bin_cmd!("treeward")
         .arg("-C")


### PR DESCRIPTION
All test-only. The common theme: security-relevant behaviors (verify/--always-verify catching content changes with unchanged metadata, diff capture of silent corruption, removed-entry fingerprint binding) were implemented but unguarded - each could be downgraded or deleted with the full suite still passing. Also fixes a provably-dead assertion disjunct and gates unix-only tests with cfg(unix) to match the Windows support posture in checksum.rs.

changelog: skip
