### PR TITLE
docs: fix doc drift in API docs, help text, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ treeward verify
 
 ## Commands
 
+### Global flags
+
+All commands accept:
+
+- `-C <DIRECTORY>` - Change to directory before operating (like `git -C`)
+- `-v` / `--verbose` - Increase log verbosity (`-v` for info, `-vv` for debug)
+- `--log-level <LEVEL>` - Set log level explicitly (`error`, `warn`, `info`, `debug`, `trace`); conflicts with `-v`
+
+Both logging flags take precedence over the `RUST_LOG` environment variable, which is also honored.
+
 ### `init` - Initialize ward files
 
 Performs first-time initialization of `.treeward` files in a directory tree. Checksums all files and creates ward
@@ -134,6 +144,9 @@ treeward status --always-verify
 
 # Show detailed per-entry diff (implies --verify)
 treeward status --diff
+
+# Also list unchanged files (shown with a "." status code)
+treeward status --all
 ```
 
 `--diff` shows field-level changes for modified and removed entries. It implies `--verify` (files with changed metadata
@@ -150,10 +163,11 @@ R  oldfile.txt
 
 **Change types:**
 
-- `Added` - New files, directories, or symlinks not in the ward
-- `Removed` - Entries in the ward that no longer exist
-- `PossiblyModified` - Files whose metadata (mtime/size) differs from ward
-- `Modified` - Content differs (checksum mismatch when verified), symlink target changed, or entry type changed
+- `A` Added - New files, directories, or symlinks not in the ward
+- `R` Removed - Entries in the ward that no longer exist
+- `M?` PossiblyModified - Files whose metadata (mtime/size) differs from ward
+- `M` Modified - Content differs (checksum mismatch when verified), symlink target changed, or entry type changed
+- `.` Unchanged - Entry matches the ward (only shown with `--all`; does not affect fingerprint or exit code)
 
 **Fingerprints:**
 

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -3,8 +3,10 @@
 //! Computes SHA-256 for regular files and returns checksum, mtime, and size
 //! values used to build `WardEntry::File`.
 //!
-//! Concurrent modification is detected by comparing mtimes before and after the
-//! read, returning `ChecksumError::ConcurrentModification` when they differ.
+//! Concurrent modification is detected two ways: mtimes are compared before and
+//! after the read, and (on Unix) the path is re-checked after reading to confirm
+//! it still names the opened file (dev/ino), catching rename/replace races. Either
+//! failure returns `ChecksumError::ConcurrentModification`.
 
 use sha2::{Digest, Sha256};
 use std::fs::File;
@@ -36,9 +38,12 @@ pub struct FileChecksum {
 /// Computes the SHA-256 checksum of a file with concurrent modification detection.
 ///
 /// # Behavior
+/// - Opens the file without following symlinks (`O_NOFOLLOW` or platform equivalent)
 /// - Records the file's modification time before reading
 /// - Reads the file in chunks and computes SHA-256
 /// - Verifies the modification time hasn't changed after reading
+/// - On Unix, also verifies the path still names the opened file (dev/ino),
+///   so rename/replace during the read is detected, not just in-place writes
 /// - Returns an error if the file was modified during checksumming
 ///
 /// # Errors (may be changed in the future)

--- a/src/cli/help_text.rs
+++ b/src/cli/help_text.rs
@@ -377,6 +377,7 @@ USAGE:
   treeward status --verify                # Checksum files with changed metadata
   treeward status --always-verify         # Checksum all files (detect silent corruption)
   treeward status --diff                  # Show detailed diff of changes (implies --verify)
+  treeward status --all                   # Also list unchanged files
   treeward -C /path/to/project status     # Check specific directory
 
 CHANGE TYPES:
@@ -489,6 +490,11 @@ Status codes:
   R   Removed - entry in ward no longer exists
   M?  PossiblyModified - metadata differs, content not verified
   M   Modified - content verified as changed
+  .   Unchanged - entry matches ward (only shown with --all)
+
+By default only changed entries are listed. With --all, unchanged entries are
+included too, which is useful for confirming exactly what a ward covers. Unchanged
+entries do not affect the fingerprint or the exit code.
 
 Paths are relative to the root directory being checked. For recursive checks, subdirectory
 paths are shown with their full relative path.

--- a/src/status.rs
+++ b/src/status.rs
@@ -54,9 +54,11 @@ pub enum StatusType {
 /// Some variants carry `ward_entry` and/or `old_ward_entry` fields:
 ///
 /// - `ward_entry: Option<WardEntry>` - The current/new ward data for this entry.
-///   Populated when `StatusPurpose::WardUpdate` is used and, for differing entries,
-///   when `DiffMode::Capture` is enabled to show new values in diffs. When present,
-///   it is always complete (never contains placeholder data).
+///   Populated when `StatusPurpose::WardUpdate` is used. Under `DiffMode::Capture`
+///   it is also populated for every Modified/PossiblyModified entry (including
+///   type changes) and for Unchanged file and symlink entries (reachable via
+///   `status --diff --all`) - but not for Added entries or unchanged directories.
+///   When present, it is always complete (never contains placeholder data).
 ///
 /// - `old_ward_entry: Option<WardEntry>` - The original ward data before the change.
 ///   Only populated when `DiffMode::Capture` is used, to enable displaying what
@@ -84,8 +86,9 @@ pub enum StatusType {
 ///   ward data.
 ///
 /// - `Unchanged`: Entry exists in both and matches. The `ward_entry` contains the
-///   current entry data (if `WardUpdate` purpose), which may have updated metadata
-///   even if content is unchanged. No `old_ward_entry` since nothing changed.
+///   current entry data (with `WardUpdate` purpose, or with `DiffMode::Capture` for
+///   file and symlink entries), which may have updated metadata even if content is
+///   unchanged. No `old_ward_entry` since nothing changed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StatusEntry {
     Added {
@@ -172,10 +175,11 @@ pub enum StatusPurpose {
     /// Display status to user.
     ///
     /// `StatusEntry` variants will usually have `ward_entry: None`. When
-    /// `DiffMode::Capture` is enabled, modified entries include `ward_entry`
-    /// to show new values in diffs. Checksumming is controlled entirely by
-    /// `ChecksumPolicy` (to determine Modified vs PossiblyModified), but the
-    /// checksum result is not retained otherwise.
+    /// `DiffMode::Capture` is enabled, entries include `ward_entry` to show
+    /// new values in diffs. Status classification (Modified vs PossiblyModified)
+    /// is driven by `ChecksumPolicy`, but `DiffMode::Capture` independently
+    /// forces checksumming of metadata-differing files - even under
+    /// `ChecksumPolicy::Never` - so diffs can show old vs new checksums.
     Display,
 
     /// Generate ward files - populate `ward_entry` with complete data.
@@ -195,6 +199,10 @@ pub enum StatusPurpose {
     WardUpdate,
 }
 
+/// Controls whether Unchanged entries appear in results.
+///
+/// NOTE: `StatusPurpose::WardUpdate` includes Unchanged entries regardless of
+/// mode, since ward building needs complete entry data for every live entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusMode {
     /// Only include files with interesting changes (added, removed, modified, possibly modified)
@@ -308,7 +316,8 @@ enum FingerprintPayload {
 /// * `PossiblyModified` - Metadata differs (only with `ChecksumPolicy::Never`)
 /// * `Modified` - Content differs (checksum mismatch, symlink target changed,
 ///   or type changed)
-/// * `Unchanged` - Entry exists in both and matches (only with `StatusMode::All`)
+/// * `Unchanged` - Entry exists in both and matches (with `StatusMode::All`, and
+///   always with `StatusPurpose::WardUpdate` regardless of mode)
 ///
 /// # Errors
 ///

--- a/src/status/tests/ward_update.rs
+++ b/src/status/tests/ward_update.rs
@@ -190,8 +190,9 @@ fn test_ward_update_purpose_ward_entry_is_some() {
 /// Verifies the checksum reuse optimization when metadata is unchanged.
 ///
 /// When `StatusPurpose::WardUpdate` is used with `ChecksumPolicy::WhenPossiblyModified`
-/// (the default), files whose metadata (mtime, size) matches the ward file should NOT
-/// be re-checksummed. Instead, the existing checksum from the ward file is reused.
+/// (the CLI's `--verify`; the CLI default is `Never`), files whose metadata (mtime,
+/// size) matches the ward file should NOT be re-checksummed. Instead, the existing
+/// checksum from the ward file is reused.
 /// This optimization makes incremental updates fast - only changed files are checksummed.
 ///
 /// This test proves the optimization works by storing a fake checksum in the ward file

--- a/src/update.rs
+++ b/src/update.rs
@@ -61,9 +61,13 @@ pub struct WardResult {
 ///
 /// * `root` - Directory to ward (will be canonicalized)
 /// * `options` - Configuration options controlling the ward operation:
-///   - `init`: Allow warding when no `.treeward` exists in root (required for first ward)
+///   - `init`: This is a first-time initialization; fails if a ward already exists
+///   - `allow_init`: Accept both initialized and uninitialized roots (idempotent mode)
 ///   - `fingerprint`: Optional fingerprint from `compute_status()` to validate before writing
 ///   - `dry_run`: Preview what would be updated without writing any files
+///   - `checksum_policy`: When to checksum files; affects reported status types and
+///     therefore fingerprint validation (must match the policy used to produce the
+///     fingerprint)
 ///
 /// # Behavior
 ///
@@ -73,9 +77,12 @@ pub struct WardResult {
 /// - This makes incremental warding very fast (only checksums what changed)
 ///
 /// **Initialization:**
-/// - If `!options.init` and no `.treeward` in root, returns `NotInitialized` error
-/// - The `init` flag only applies to the root directory - subdirectories can always
-///   have `.treeward` files created without `init`
+/// - Without `init` or `allow_init`, a missing root `.treeward` is a `NotInitialized` error
+/// - With `init` (and not `allow_init`), an existing root `.treeward` is an
+///   `AlreadyInitialized` error - `init` asserts first-time use
+/// - `allow_init` bypasses both checks, accepting either state
+/// - These checks only apply to the root directory - subdirectories always
+///   have `.treeward` files created as needed
 ///
 /// **Fingerprint validation:**
 /// - If `options.fingerprint` is provided, validates current changes match the fingerprint

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -415,7 +415,7 @@ fn update_allow_init_is_idempotent() {
         "ward file content should remain identical after third run"
     );
 
-    // Verify status shows no changes
+    // verify must report a clean tree
     treeward_cmd(temp.path()).arg("verify").assert().success();
 }
 


### PR DESCRIPTION
Docstrings, help text, and the README had drifted from actual behavior. The user-visible gaps were `status --all` (showcased in the demo gif but documented nowhere, including its `.` status code) and the global logging flags missing from the README. The API-doc fixes correct claims that were provably wrong against the code: ward_directory's init/allow_init semantics, where Unchanged entries and ward_entry actually get populated, the DiffMode::Capture checksumming override, and the undocumented dev/ino identity re-check in concurrent-modification detection.

changelog: skip
