### PR TITLE
refactor: idiomatic cleanups across status, checksum, CLI, and tests

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -10,7 +10,6 @@
 
 use sha2::{Digest, Sha256};
 use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
@@ -61,15 +60,7 @@ pub fn checksum_file(path: &Path) -> Result<FileChecksum, ChecksumError> {
     let mtime_before = metadata_before.modified().map_err(ChecksumError::Io)?;
 
     let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 8192];
-
-    loop {
-        let bytes_read = file.read(&mut buffer).map_err(ChecksumError::Io)?;
-        if bytes_read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..bytes_read]);
-    }
+    std::io::copy(&mut file, &mut hasher).map_err(ChecksumError::Io)?;
 
     let metadata_after = file.metadata().map_err(ChecksumError::Io)?;
     let mtime_after = metadata_after.modified().map_err(ChecksumError::Io)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub enum Command {
 
     /// Verify consistency of the ward, exit with success if no inconsistency.
     #[command(long_about = help_text::VERIFY_LONG_ABOUT)]
-    Verify {},
+    Verify,
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use cli::{Cli, Command, LogLevel};
 use status::ChecksumPolicy;
 use std::fmt as stdfmt;
 use std::io::{IsTerminal, stderr};
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::ExitCode;
 use tracing::{Event, Level, Subscriber, error, info};
 use tracing_subscriber::filter::EnvFilter;
@@ -78,7 +78,7 @@ fn main() -> ExitCode {
         return WardExitCode::any_error();
     }
 
-    let current_dir = PathBuf::from(".");
+    let current_dir = Path::new(".");
 
     let result: anyhow::Result<ExitCode> = match cli.command {
         Command::Update {
@@ -116,7 +116,7 @@ fn main() -> ExitCode {
             all,
             diff,
         } => handle_status(current_dir, verify, always_verify, all, diff),
-        Command::Verify {} => handle_verify(current_dir),
+        Command::Verify => handle_verify(current_dir),
     };
 
     match result {
@@ -129,7 +129,7 @@ fn main() -> ExitCode {
 }
 
 fn handle_init_or_update(
-    path: PathBuf,
+    path: &Path,
     init: bool,
     allow_init: bool,
     fingerprint: Option<String>,
@@ -145,7 +145,7 @@ fn handle_init_or_update(
         checksum_policy: checksum_policy_from_flags(always_verify, verify),
     };
 
-    let result = ward_directory(&path, options)?;
+    let result = ward_directory(path, options)?;
 
     if dry_run {
         info!("DRY RUN - no files were modified");
@@ -164,7 +164,7 @@ fn handle_init_or_update(
 }
 
 fn handle_status(
-    path: PathBuf,
+    path: &Path,
     verify: bool,
     always_verify: bool,
     all: bool,
@@ -186,7 +186,7 @@ fn handle_status(
     };
 
     let result = status::compute_status(
-        &path,
+        path,
         policy,
         mode,
         status::StatusPurpose::Display,
@@ -221,9 +221,9 @@ fn handle_status(
     Ok(WardExitCode::status_unclean())
 }
 
-fn handle_verify(path: PathBuf) -> anyhow::Result<ExitCode> {
+fn handle_verify(path: &Path) -> anyhow::Result<ExitCode> {
     let result = status::compute_status(
-        &path,
+        path,
         ChecksumPolicy::Always,
         status::StatusMode::Interesting,
         status::StatusPurpose::Display,

--- a/src/status.rs
+++ b/src/status.rs
@@ -280,6 +280,20 @@ enum FingerprintPayload {
     Removed { ward_entry: WardEntry },
 }
 
+/// Walk-invariant parameters for the recursive status traversal.
+///
+/// Bundles the canonicalized tree root with the knobs that stay fixed for the
+/// duration of a walk, so the recursion passes one context instead of
+/// repeating the same argument list at every level.
+#[derive(Debug, Clone, Copy)]
+struct WalkContext<'a> {
+    tree_root: &'a Path,
+    policy: ChecksumPolicy,
+    mode: StatusMode,
+    purpose: StatusPurpose,
+    diff_mode: DiffMode,
+}
+
 /// Compare filesystem state against ward files to detect changes.
 ///
 /// Recursively walks the directory tree starting from `root`, comparing the
@@ -339,16 +353,14 @@ pub fn compute_status(
     let mut statuses = Vec::new();
     let mut fingerprint_records = Vec::new();
 
-    walk_directory(
-        &root,
-        &root,
-        &mut statuses,
-        &mut fingerprint_records,
+    let ctx = WalkContext {
+        tree_root: &root,
         policy,
         mode,
         purpose,
         diff_mode,
-    )?;
+    };
+    walk_directory(ctx, &root, &mut statuses, &mut fingerprint_records)?;
 
     statuses.sort_by(|a, b| a.path().cmp(b.path()));
     // Keep fingerprint deterministic even if traversal order changes in the future.
@@ -366,16 +378,11 @@ pub fn compute_status(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_directory(
-    tree_root: &Path,
+    ctx: WalkContext<'_>,
     current_dir: &Path,
     statuses: &mut Vec<StatusEntry>,
     fingerprint_records: &mut Vec<FingerprintRecord>,
-    policy: ChecksumPolicy,
-    mode: StatusMode,
-    purpose: StatusPurpose,
-    diff_mode: DiffMode,
 ) -> Result<(), StatusError> {
     info!("Entering directory {}", current_dir.display());
 
@@ -390,47 +397,25 @@ fn walk_directory(
     };
 
     compare_entries(
-        tree_root,
+        ctx,
         current_dir,
         &ward_entries,
         &fs_entries,
         statuses,
         fingerprint_records,
-        policy,
-        mode,
-        purpose,
-        diff_mode,
     )?;
 
     for (name, entry) in &fs_entries {
         if matches!(entry, FsEntry::Dir { .. }) {
             let child_path = current_dir.join(name);
-            walk_directory(
-                tree_root,
-                &child_path,
-                statuses,
-                fingerprint_records,
-                policy,
-                mode,
-                purpose,
-                diff_mode,
-            )?;
+            walk_directory(ctx, &child_path, statuses, fingerprint_records)?;
         }
     }
 
     for (name, entry) in &ward_entries {
         if matches!(entry, WardEntry::Dir {}) && !fs_entries.contains_key(name) {
             let child_path = current_dir.join(name);
-            walk_directory(
-                tree_root,
-                &child_path,
-                statuses,
-                fingerprint_records,
-                policy,
-                mode,
-                purpose,
-                diff_mode,
-            )?;
+            walk_directory(ctx, &child_path, statuses, fingerprint_records)?;
         }
     }
 
@@ -470,24 +455,19 @@ fn build_ward_entry_from_fs(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn compare_entries(
-    tree_root: &Path,
+    ctx: WalkContext<'_>,
     current_dir: &Path,
     ward_entries: &BTreeMap<String, WardEntry>,
     fs_entries: &BTreeMap<String, FsEntry>,
     statuses: &mut Vec<StatusEntry>,
     fingerprint_records: &mut Vec<FingerprintRecord>,
-    policy: ChecksumPolicy,
-    mode: StatusMode,
-    purpose: StatusPurpose,
-    diff_mode: DiffMode,
 ) -> Result<(), StatusError> {
     for (name, fs_entry) in fs_entries {
         if !ward_entries.contains_key(name) {
-            let relative_path = make_relative_path(tree_root, current_dir, name)?;
+            let relative_path = make_relative_path(ctx.tree_root, current_dir, name)?;
 
-            let ward_entry = if purpose == StatusPurpose::WardUpdate {
+            let ward_entry = if ctx.purpose == StatusPurpose::WardUpdate {
                 Some(build_ward_entry_from_fs(current_dir, name, fs_entry)?)
             } else {
                 None
@@ -497,7 +477,7 @@ fn compare_entries(
                 name,
                 fs_entry,
                 ward_entry.as_ref(),
-                policy,
+                ctx.policy,
             )?;
 
             statuses.push(StatusEntry::Added {
@@ -514,8 +494,8 @@ fn compare_entries(
 
     for (name, removed_ward_entry) in ward_entries {
         if !fs_entries.contains_key(name) {
-            let relative_path = make_relative_path(tree_root, current_dir, name)?;
-            let old_ward_entry = if diff_mode == DiffMode::Capture {
+            let relative_path = make_relative_path(ctx.tree_root, current_dir, name)?;
+            let old_ward_entry = if ctx.diff_mode == DiffMode::Capture {
                 Some(removed_ward_entry.clone())
             } else {
                 None
@@ -537,17 +517,13 @@ fn compare_entries(
     for (name, ward_entry) in ward_entries {
         if let Some(fs_entry) = fs_entries.get(name) {
             check_modification(
-                tree_root,
+                ctx,
                 current_dir,
                 name,
                 ward_entry,
                 fs_entry,
                 statuses,
                 fingerprint_records,
-                policy,
-                mode,
-                purpose,
-                diff_mode,
             )?;
         }
     }
@@ -566,21 +542,16 @@ fn compare_entries(
 /// Type changes (e.g., file becoming symlink) are always reported as Modified.
 ///
 /// Appends the resulting `StatusEntry` to `statuses` based on `mode` and `purpose`.
-#[allow(clippy::too_many_arguments)]
 fn check_modification(
-    tree_root: &Path,
+    ctx: WalkContext<'_>,
     current_dir: &Path,
     name: &str,
     ward_entry: &WardEntry,
     fs_entry: &FsEntry,
     statuses: &mut Vec<StatusEntry>,
     fingerprint_records: &mut Vec<FingerprintRecord>,
-    policy: ChecksumPolicy,
-    mode: StatusMode,
-    purpose: StatusPurpose,
-    diff_mode: DiffMode,
 ) -> Result<(), StatusError> {
-    let relative_path = make_relative_path(tree_root, current_dir, name)?;
+    let relative_path = make_relative_path(ctx.tree_root, current_dir, name)?;
     let absolute_path = current_dir.join(name);
 
     match (ward_entry, fs_entry) {
@@ -598,13 +569,14 @@ fn check_modification(
             let fs_mtime_nanos = mtime_to_nanos(fs_mtime)?;
             let metadata_differs = fs_mtime_nanos != *ward_mtime_nanos || fs_size != ward_size;
 
-            let need_checksum_for_status = match policy {
+            let need_checksum_for_status = match ctx.policy {
                 ChecksumPolicy::Never => false,
                 ChecksumPolicy::WhenPossiblyModified => metadata_differs,
                 ChecksumPolicy::Always => true,
             };
-            let need_checksum_for_ward = purpose == StatusPurpose::WardUpdate && metadata_differs;
-            let need_checksum_for_diff = diff_mode == DiffMode::Capture && metadata_differs;
+            let need_checksum_for_ward =
+                ctx.purpose == StatusPurpose::WardUpdate && metadata_differs;
+            let need_checksum_for_diff = ctx.diff_mode == DiffMode::Capture && metadata_differs;
             let need_checksum =
                 need_checksum_for_status || need_checksum_for_ward || need_checksum_for_diff;
 
@@ -616,7 +588,7 @@ fn check_modification(
             };
 
             let new_ward_entry =
-                if purpose == StatusPurpose::WardUpdate || diff_mode == DiffMode::Capture {
+                if ctx.purpose == StatusPurpose::WardUpdate || ctx.diff_mode == DiffMode::Capture {
                     Some(match &new_checksum {
                         Some(c) => WardEntry::File {
                             sha256: c.sha256.clone(),
@@ -636,7 +608,7 @@ fn check_modification(
             // Capture old_ward_entry when diff mode is enabled and the entry differs
             // (either metadata or checksum - for --always-verify detecting silent corruption)
             let old_ward_entry =
-                if diff_mode == DiffMode::Capture && (metadata_differs || sha256_differs) {
+                if ctx.diff_mode == DiffMode::Capture && (metadata_differs || sha256_differs) {
                     Some(ward_entry.clone())
                 } else {
                     None
@@ -682,7 +654,7 @@ fn check_modification(
                     status_type: StatusType::Modified,
                     payload: fingerprint_payload,
                 });
-            } else if mode == StatusMode::All || purpose == StatusPurpose::WardUpdate {
+            } else if ctx.mode == StatusMode::All || ctx.purpose == StatusPurpose::WardUpdate {
                 statuses.push(StatusEntry::Unchanged {
                     path: relative_path,
                     ward_entry: new_ward_entry,
@@ -690,8 +662,8 @@ fn check_modification(
             }
         }
         (WardEntry::Dir {}, FsEntry::Dir { .. }) => {
-            if mode == StatusMode::All || purpose == StatusPurpose::WardUpdate {
-                let new_ward_entry = if purpose == StatusPurpose::WardUpdate {
+            if ctx.mode == StatusMode::All || ctx.purpose == StatusPurpose::WardUpdate {
+                let new_ward_entry = if ctx.purpose == StatusPurpose::WardUpdate {
                     Some(WardEntry::Dir {})
                 } else {
                     None
@@ -711,7 +683,7 @@ fn check_modification(
             },
         ) => {
             let new_ward_entry =
-                if purpose == StatusPurpose::WardUpdate || diff_mode == DiffMode::Capture {
+                if ctx.purpose == StatusPurpose::WardUpdate || ctx.diff_mode == DiffMode::Capture {
                     Some(WardEntry::Symlink {
                         symlink_target: fs_target.clone(),
                     })
@@ -720,7 +692,7 @@ fn check_modification(
                 };
 
             if ward_target != fs_target {
-                let old_ward_entry = if diff_mode == DiffMode::Capture {
+                let old_ward_entry = if ctx.diff_mode == DiffMode::Capture {
                     Some(ward_entry.clone())
                 } else {
                     None
@@ -737,7 +709,7 @@ fn check_modification(
                         symlink_target: fs_target.clone(),
                     },
                 });
-            } else if mode == StatusMode::All || purpose == StatusPurpose::WardUpdate {
+            } else if ctx.mode == StatusMode::All || ctx.purpose == StatusPurpose::WardUpdate {
                 statuses.push(StatusEntry::Unchanged {
                     path: relative_path,
                     ward_entry: new_ward_entry,
@@ -747,12 +719,12 @@ fn check_modification(
         _ => {
             // Type change (e.g., file -> symlink)
             let new_ward_entry =
-                if purpose == StatusPurpose::WardUpdate || diff_mode == DiffMode::Capture {
+                if ctx.purpose == StatusPurpose::WardUpdate || ctx.diff_mode == DiffMode::Capture {
                     Some(build_ward_entry_from_fs(current_dir, name, fs_entry)?)
                 } else {
                     None
                 };
-            let old_ward_entry = if diff_mode == DiffMode::Capture {
+            let old_ward_entry = if ctx.diff_mode == DiffMode::Capture {
                 Some(ward_entry.clone())
             } else {
                 None
@@ -762,7 +734,7 @@ fn check_modification(
                 name,
                 fs_entry,
                 new_ward_entry.as_ref(),
-                policy,
+                ctx.policy,
             )?;
             statuses.push(StatusEntry::Modified {
                 path: relative_path.clone(),

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,9 +10,7 @@ use crate::status::{
     ChecksumPolicy, DiffMode, StatusEntry, StatusError, StatusMode, StatusPurpose,
     build_ward_files, compute_status,
 };
-#[cfg(test)]
-use crate::ward_file::WardEntry;
-use crate::ward_file::{WardFile, WardFileError};
+use crate::ward_file::{WardEntry, WardFile, WardFileError};
 use std::path::{Path, PathBuf, StripPrefixError};
 
 #[derive(Debug, thiserror::Error)]
@@ -172,7 +170,7 @@ pub fn ward_directory(root: &Path, options: WardOptions) -> Result<WardResult, W
             StatusEntry::Added { ward_entry, .. }
             | StatusEntry::Modified { ward_entry, .. }
             | StatusEntry::PossiblyModified { ward_entry, .. } => {
-                matches!(ward_entry, Some(crate::ward_file::WardEntry::File { .. }))
+                matches!(ward_entry, Some(WardEntry::File { .. }))
             }
             _ => false,
         })

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,4 +1,7 @@
+mod common;
+
 use assert_cmd::cargo::cargo_bin_cmd;
+use common::treeward_cmd;
 use predicates::prelude::*;
 use std::fs;
 #[cfg(unix)]
@@ -10,9 +13,7 @@ fn init_creates_ward_files() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -28,10 +29,8 @@ fn init_verbose_shows_warded_count() {
     fs::write(temp.path().join("file1.txt"), "hello").unwrap();
     fs::write(temp.path().join("file2.txt"), "world").unwrap();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .arg("-v")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -43,9 +42,7 @@ fn init_dry_run_skips_writes() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("init")
         .arg("--dry-run")
         .assert()
@@ -60,16 +57,9 @@ fn init_fails_when_already_initialized() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("init")
         .assert()
         .failure()
@@ -77,6 +67,9 @@ fn init_fails_when_already_initialized() {
         .stderr(predicate::str::contains("treeward update"));
 }
 
+// Intentionally hand-rolled: this test exercises -C with a relative path
+// resolved against the process working directory, which the shared helper
+// (absolute-path -C) cannot express.
 #[test]
 fn init_with_c_flag_changes_directory() {
     let temp = TempDir::new().unwrap();
@@ -109,12 +102,7 @@ fn init_exits_code_255_on_permission_error() {
     perms.set_mode(0o555);
     fs::set_permissions(temp.path(), perms.clone()).unwrap();
 
-    let output = cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .output()
-        .unwrap();
+    let output = treeward_cmd(temp.path()).arg("init").output().unwrap();
 
     // Restore permissions for cleanup
     perms.set_mode(0o755);

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -1,4 +1,7 @@
+mod common;
+
 use assert_cmd::cargo::cargo_bin_cmd;
+use common::treeward_cmd;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
@@ -13,10 +16,8 @@ fn temp_dir_with_file() -> TempDir {
 fn init_without_flags_respects_rust_log_info() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "info")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -27,10 +28,8 @@ fn init_without_flags_respects_rust_log_info() {
 fn init_without_flags_respects_rust_log_warn() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "warn")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -41,11 +40,9 @@ fn init_without_flags_respects_rust_log_warn() {
 fn verbose_overrides_rust_log_warn() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "warn")
         .arg("-v")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -56,11 +53,9 @@ fn verbose_overrides_rust_log_warn() {
 fn verbose_debug_overrides_rust_log_warn() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "warn")
         .arg("-vv")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -71,12 +66,10 @@ fn verbose_debug_overrides_rust_log_warn() {
 fn log_level_overrides_rust_log_warn() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "warn")
         .arg("--log-level")
         .arg("info")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -87,12 +80,10 @@ fn log_level_overrides_rust_log_warn() {
 fn trace_log_level_emits_debug_messages() {
     let temp = temp_dir_with_file();
 
-    cargo_bin_cmd!("treeward")
+    treeward_cmd(temp.path())
         .env("RUST_LOG", "warn")
         .arg("--log-level")
         .arg("trace")
-        .arg("-C")
-        .arg(temp.path())
         .arg("init")
         .assert()
         .success()
@@ -135,11 +126,7 @@ fn status_permission_error_logs_to_stderr_not_stdout() {
     // Remove all permissions so entering the directory fails.
     fs::set_permissions(&protected, fs::Permissions::from_mode(0o000)).unwrap();
 
-    let assert = cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("status")
-        .assert();
+    let assert = treeward_cmd(temp.path()).arg("status").assert();
 
     assert
         .failure()
@@ -158,9 +145,7 @@ fn warn_error_emojis_suppressed_when_not_tty() {
     fs::set_permissions(&protected, fs::Permissions::from_mode(0o000)).unwrap();
 
     // capture() makes stdout/stderr non-tty
-    let output = cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    let output = treeward_cmd(temp.path())
         .arg("status")
         .assert()
         .failure()

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,4 +1,7 @@
+mod common;
+
 use assert_cmd::cargo::cargo_bin_cmd;
+use common::treeward_cmd;
 use filetime::{FileTime, set_file_mtime};
 use predicates::prelude::*;
 use std::fs;
@@ -9,16 +12,9 @@ fn verify_success_when_clean() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("verify")
         .assert()
         .success()
@@ -30,18 +26,11 @@ fn verify_fails_on_added_file() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
     fs::write(temp.path().join("new.txt"), "new").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("verify")
         .assert()
         .failure()
@@ -55,18 +44,11 @@ fn verify_fails_on_modified_file() {
     let file_path = temp.path().join("file.txt");
     fs::write(&file_path, "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
     fs::write(&file_path, "changed").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("verify")
         .assert()
         .failure()
@@ -85,12 +67,7 @@ fn verify_detects_content_change_with_unchanged_metadata() {
     let file_path = temp.path().join("file.txt");
     fs::write(&file_path, "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
     let original_mtime =
         FileTime::from_system_time(fs::metadata(&file_path).unwrap().modified().unwrap());
@@ -99,17 +76,13 @@ fn verify_detects_content_change_with_unchanged_metadata() {
 
     // Sanity-check the premise: metadata-only status must see a clean tree,
     // otherwise this test is not exercising the checksum path at all.
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("status")
         .assert()
         .success()
         .stdout(predicate::str::is_empty());
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
+    treeward_cmd(temp.path())
         .arg("verify")
         .assert()
         .failure()
@@ -117,6 +90,9 @@ fn verify_detects_content_change_with_unchanged_metadata() {
         .stderr(predicate::str::contains("Verification failed"));
 }
 
+// Intentionally hand-rolled: this test exercises -C with a relative path
+// resolved against the process working directory, which the shared helper
+// (absolute-path -C) cannot express.
 #[test]
 fn verify_with_c_flag_changes_directory() {
     let temp = TempDir::new().unwrap();
@@ -124,12 +100,7 @@ fn verify_with_c_flag_changes_directory() {
     fs::create_dir(&subdir).unwrap();
     fs::write(subdir.join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(&subdir)
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(&subdir).arg("init").assert().success();
 
     cargo_bin_cmd!("treeward")
         .current_dir(temp.path())
@@ -147,21 +118,11 @@ fn verify_exits_code_1_when_unclean() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.txt"), "hello").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
     fs::write(temp.path().join("new.txt"), "added file").unwrap();
 
-    let output = cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("verify")
-        .output()
-        .unwrap();
+    let output = treeward_cmd(temp.path()).arg("verify").output().unwrap();
 
     assert_eq!(
         output.status.code(),
@@ -187,12 +148,7 @@ fn verify_exits_code_255_on_permission_error() {
     fs::create_dir(temp.path().join("subdir")).unwrap();
     fs::write(temp.path().join("subdir/nested.txt"), "nested").unwrap();
 
-    cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("init")
-        .assert()
-        .success();
+    treeward_cmd(temp.path()).arg("init").assert().success();
 
     // Remove read permission from subdir
     let subdir = temp.path().join("subdir");
@@ -200,12 +156,7 @@ fn verify_exits_code_255_on_permission_error() {
     perms.set_mode(0o000);
     fs::set_permissions(&subdir, perms.clone()).unwrap();
 
-    let output = cargo_bin_cmd!("treeward")
-        .arg("-C")
-        .arg(temp.path())
-        .arg("verify")
-        .output()
-        .unwrap();
+    let output = treeward_cmd(temp.path()).arg("verify").output().unwrap();
 
     // Restore permissions for cleanup
     perms.set_mode(0o755);


### PR DESCRIPTION
Behavior-preserving cleanups. The substantive one: a WalkContext struct now carries the tree root and the four walk-invariant knobs through the recursive status traversal, eliminating all three too_many_arguments suppressions instead of papering over them. The rest are mechanical: unconditional WardEntry import, io::copy into the hasher, unit Verify variant, &Path handler signatures, and converting tests/{init,verify,logging}.rs to the shared treeward_cmd helper (the two -C relative-path tests stay hand-rolled, now with a comment saying why).

changelog: skip
