### PR TITLE
refactor: remove redundant code paths and duplicate status-code mapping

### DIFF
--- a/src/diffing.rs
+++ b/src/diffing.rs
@@ -45,26 +45,15 @@ fn format_target(target: &Path) -> String {
 
 pub fn print_statuses(statuses: &[status::StatusEntry], show_diff: bool) {
     for entry in statuses {
-        let status_code = match entry.status_type() {
-            status::StatusType::Added => "A",
-            status::StatusType::Removed => "R",
-            status::StatusType::PossiblyModified => "M?",
-            status::StatusType::Modified => "M",
-            status::StatusType::Unchanged => ".",
-        };
+        let status_code = status::status_type_code(entry.status_type());
 
         println!("{:<2} {}", status_code, escape_control(entry.path()));
 
         if show_diff {
-            print_diff(entry);
+            for line in format_diff_lines(entry) {
+                println!("{}", line);
+            }
         }
-    }
-}
-
-fn print_diff(entry: &status::StatusEntry) {
-    let lines = format_diff_lines(entry);
-    for line in lines {
-        println!("{}", line);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,10 +198,6 @@ fn handle_status(
         .iter()
         .any(|c| c.status_type() != status::StatusType::Unchanged);
 
-    if result.statuses.is_empty() {
-        return Ok(ExitCode::SUCCESS);
-    }
-
     diffing::print_statuses(&result.statuses, diff);
 
     if !has_interesting_changes {

--- a/src/status.rs
+++ b/src/status.rs
@@ -131,10 +131,10 @@ impl StatusEntry {
 
     pub fn ward_entry(&self) -> Option<&WardEntry> {
         match self {
-            StatusEntry::Added { ward_entry, .. } => ward_entry.as_ref(),
-            StatusEntry::Modified { ward_entry, .. } => ward_entry.as_ref(),
-            StatusEntry::Unchanged { ward_entry, .. } => ward_entry.as_ref(),
-            StatusEntry::PossiblyModified { ward_entry, .. } => ward_entry.as_ref(),
+            StatusEntry::Added { ward_entry, .. }
+            | StatusEntry::Modified { ward_entry, .. }
+            | StatusEntry::Unchanged { ward_entry, .. }
+            | StatusEntry::PossiblyModified { ward_entry, .. } => ward_entry.as_ref(),
             StatusEntry::Removed { .. } => None,
         }
     }
@@ -492,31 +492,11 @@ fn compare_entries(
         }
     }
 
-    for (name, removed_ward_entry) in ward_entries {
-        if !fs_entries.contains_key(name) {
-            let relative_path = make_relative_path(ctx.tree_root, current_dir, name)?;
-            let old_ward_entry = if ctx.diff_mode == DiffMode::Capture {
-                Some(removed_ward_entry.clone())
-            } else {
-                None
-            };
-            statuses.push(StatusEntry::Removed {
-                path: relative_path.clone(),
-                old_ward_entry,
-            });
-            fingerprint_records.push(FingerprintRecord {
-                path: relative_path,
-                status_type: StatusType::Removed,
-                payload: FingerprintPayload::Removed {
-                    ward_entry: removed_ward_entry.clone(),
-                },
-            });
-        }
-    }
-
+    // Ordering between Removed and Modified entries does not matter here:
+    // compute_status sorts statuses and fingerprint records after the walk.
     for (name, ward_entry) in ward_entries {
-        if let Some(fs_entry) = fs_entries.get(name) {
-            check_modification(
+        match fs_entries.get(name) {
+            Some(fs_entry) => check_modification(
                 ctx,
                 current_dir,
                 name,
@@ -524,7 +504,26 @@ fn compare_entries(
                 fs_entry,
                 statuses,
                 fingerprint_records,
-            )?;
+            )?,
+            None => {
+                let relative_path = make_relative_path(ctx.tree_root, current_dir, name)?;
+                let old_ward_entry = if ctx.diff_mode == DiffMode::Capture {
+                    Some(ward_entry.clone())
+                } else {
+                    None
+                };
+                statuses.push(StatusEntry::Removed {
+                    path: relative_path.clone(),
+                    old_ward_entry,
+                });
+                fingerprint_records.push(FingerprintRecord {
+                    path: relative_path,
+                    status_type: StatusType::Removed,
+                    payload: FingerprintPayload::Removed {
+                        ward_entry: ward_entry.clone(),
+                    },
+                });
+            }
         }
     }
 
@@ -833,7 +832,7 @@ fn fingerprint_payload_from_fs_entry(
 }
 
 /// Stable short code used both in terminal output and fingerprint records.
-fn status_type_code(status_type: StatusType) -> &'static str {
+pub(crate) fn status_type_code(status_type: StatusType) -> &'static str {
     match status_type {
         StatusType::Added => "A",
         StatusType::Removed => "R",


### PR DESCRIPTION
Behavior-preserving cleanups. The one worth calling out: the status-code mapping existed twice (status_type_code feeds fingerprint records, diffing.rs had its own copy for terminal output), so the two could silently diverge and break the documented parity between displayed codes and fingerprint input; print_statuses now uses the shared pub(crate) function. The merged single loop in compare_entries relies on results being sorted after the walk, which is now noted in a comment.

The removed is_empty() early return in handle_status was a special case fully subsumed by the path below it: with an empty status list, print_statuses prints nothing (empty loop), has_interesting_changes is false (any() over an empty iterator), and the !has_interesting_changes branch returns the same Ok(ExitCode::SUCCESS) before any fingerprint output.

changelog: skip
