### PR TITLE
fix: error on entries vanishing mid-listing instead of misreporting removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ initialization and updates checksum every file.
 ### Concurrent modification detection
 
 Before and after checksumming a file, treeward compares mtime to detect changes during the read operation. If detected,
-it returns an error (no retry logic). Note that detection can never be guaranteed and should be considered a courtesy
-best effort.
+it returns an error (no retry logic). Similarly, an entry that vanishes between listing a directory and inspecting it is
+reported as a fatal concurrent-modification error, never silently treated as a removal. Note that detection can never be
+guaranteed and should be considered a courtesy best effort.
 
 ### TOCTOU protection
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -17,3 +17,7 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
   is unambiguous; all other Unicode is printed unchanged. This prevents crafted names from injecting terminal escape
   sequences (OSC/CSI) into the listing. Diagnostic logging (`-v`) and error messages on stderr are NOT covered by this
   guarantee and may contain raw names.
+
+- A child entry that vanishes between listing a directory and inspecting it is a fatal error (concurrent modification);
+  it is never silently treated as removed. This includes a directory that disappears between being listed and being
+  walked. A directory that was already absent when its parent was listed is reported as removed by its parent.

--- a/src/dir_list.rs
+++ b/src/dir_list.rs
@@ -16,6 +16,20 @@ const TREEWARD_FILENAME: &str = ".treeward";
 pub enum DirListError {
     #[error("IO error: {0}")]
     Io(std::io::Error),
+    /// The listed directory itself does not exist.
+    ///
+    /// Kept distinct from `Io` so callers can treat a vanished directory as
+    /// "removed" without conflating it with per-entry NotFound inside an
+    /// existing directory — conflating the two would make a directory full of
+    /// intact files look empty when a single child vanishes mid-listing.
+    #[error("directory not found: {0}")]
+    DirectoryNotFound(PathBuf),
+    /// A child entry vanished between `read_dir` and inspecting it.
+    ///
+    /// Fatal, mirroring the checksumming concurrent-modification policy: a
+    /// race must surface as an error, never be misreported as a removal.
+    #[error("entry vanished during listing (concurrent modification): {0}")]
+    EntryVanished(PathBuf),
     #[error("Permission denied: {0}")]
     PermissionDenied(PathBuf),
     #[error("non-UTF-8 path not supported: {0:?}")]
@@ -35,6 +49,8 @@ pub fn list_directory(root: &Path) -> Result<BTreeMap<String, FsEntry>, DirListE
     let read_dir = std::fs::read_dir(root).map_err(|e| {
         if e.kind() == std::io::ErrorKind::PermissionDenied {
             DirListError::PermissionDenied(root.to_path_buf())
+        } else if e.kind() == std::io::ErrorKind::NotFound {
+            DirListError::DirectoryNotFound(root.to_path_buf())
         } else {
             DirListError::Io(e)
         }
@@ -50,13 +66,7 @@ pub fn list_directory(root: &Path) -> Result<BTreeMap<String, FsEntry>, DirListE
             continue;
         }
 
-        let metadata = std::fs::symlink_metadata(&path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                DirListError::PermissionDenied(path.clone())
-            } else {
-                DirListError::Io(e)
-            }
-        })?;
+        let metadata = std::fs::symlink_metadata(&path).map_err(|e| child_error(&path, e))?;
 
         let filename = path
             .file_name()
@@ -68,13 +78,7 @@ pub fn list_directory(root: &Path) -> Result<BTreeMap<String, FsEntry>, DirListE
         let file_type = metadata.file_type();
 
         let fs_entry = if file_type.is_symlink() {
-            let symlink_target = std::fs::read_link(&path).map_err(|e| {
-                if e.kind() == std::io::ErrorKind::PermissionDenied {
-                    DirListError::PermissionDenied(path.clone())
-                } else {
-                    DirListError::Io(e)
-                }
-            })?;
+            let symlink_target = std::fs::read_link(&path).map_err(|e| child_error(&path, e))?;
             FsEntry::Symlink { symlink_target }
         } else if file_type.is_dir() {
             let mtime = metadata.modified().map_err(DirListError::Io)?;
@@ -91,6 +95,19 @@ pub fn list_directory(root: &Path) -> Result<BTreeMap<String, FsEntry>, DirListE
     }
 
     Ok(entries)
+}
+
+/// Maps a per-child inspection failure during listing.
+///
+/// NotFound here means the child existed in the directory listing moments
+/// ago: a concurrent modification, kept deliberately distinct from the
+/// directory-level NotFound handled at the `read_dir` open.
+fn child_error(path: &Path, e: std::io::Error) -> DirListError {
+    match e.kind() {
+        std::io::ErrorKind::PermissionDenied => DirListError::PermissionDenied(path.to_path_buf()),
+        std::io::ErrorKind::NotFound => DirListError::EntryVanished(path.to_path_buf()),
+        _ => DirListError::Io(e),
+    }
 }
 
 #[cfg(test)]
@@ -166,6 +183,26 @@ mod tests {
         let entries = list_directory(root).unwrap();
 
         assert_eq!(entries.len(), 0);
+    }
+
+    /// A missing directory must map to `DirectoryNotFound`, not generic `Io`.
+    ///
+    /// The status walk keys on this variant to tell "this ward-recorded
+    /// directory is genuinely absent" apart from per-entry failures inside an
+    /// existing directory; conflating the two under `Io(NotFound)` is what
+    /// once let a single vanished child make an intact directory look empty.
+    #[test]
+    fn test_missing_directory_returns_directory_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("gone");
+
+        let result = list_directory(&missing);
+
+        assert!(
+            matches!(result, Err(DirListError::DirectoryNotFound(ref p)) if p == &missing),
+            "expected DirectoryNotFound, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -360,7 +360,13 @@ pub fn compute_status(
         purpose,
         diff_mode,
     };
-    walk_directory(ctx, &root, &mut statuses, &mut fingerprint_records)?;
+    walk_directory(
+        ctx,
+        &root,
+        DirExpectation::Present,
+        &mut statuses,
+        &mut fingerprint_records,
+    )?;
 
     statuses.sort_by(|a, b| a.path().cmp(b.path()));
     // Keep fingerprint deterministic even if traversal order changes in the future.
@@ -378,9 +384,28 @@ pub fn compute_status(
     })
 }
 
+/// How a directory's absence should be interpreted when walking into it.
+///
+/// The same `DirectoryNotFound` from listing means two very different things
+/// depending on where the walk learned about the directory, so the caller's
+/// knowledge has to travel with the recursion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirExpectation {
+    /// Observed on the filesystem moments ago (in the parent's listing, or as
+    /// the canonicalized root): finding it gone now is a concurrent
+    /// modification and fatal.
+    Present,
+    /// Known only from ward state: it is expected to be missing on disk. The
+    /// walk proceeds with an empty listing — typically a no-op, since the
+    /// directory's own ward file vanished with it; the parent's comparison is
+    /// what reports the directory as Removed.
+    MaybeRemoved,
+}
+
 fn walk_directory(
     ctx: WalkContext<'_>,
     current_dir: &Path,
+    expectation: DirExpectation,
     statuses: &mut Vec<StatusEntry>,
     fingerprint_records: &mut Vec<FingerprintRecord>,
 ) -> Result<(), StatusError> {
@@ -390,9 +415,16 @@ fn walk_directory(
     let ward_file = WardFile::load_if_exists(&ward_path)?;
     let ward_entries = ward_file.map(|wf| wf.entries).unwrap_or_default();
 
+    // Per-entry failures inside an existing directory (including a child
+    // vanishing mid-listing) are always fatal and propagate. A missing
+    // directory is tolerated only when ward state is the sole reason we are
+    // here; a directory that was just observed on the filesystem must still
+    // exist, or we are racing a concurrent modification.
     let fs_entries = match list_directory(current_dir) {
         Ok(entries) => entries,
-        Err(DirListError::Io(e)) if e.kind() == ErrorKind::NotFound => BTreeMap::new(),
+        Err(DirListError::DirectoryNotFound(_)) if expectation == DirExpectation::MaybeRemoved => {
+            BTreeMap::new()
+        }
         Err(e) => return Err(StatusError::DirList(e)),
     };
 
@@ -408,14 +440,26 @@ fn walk_directory(
     for (name, entry) in &fs_entries {
         if matches!(entry, FsEntry::Dir { .. }) {
             let child_path = current_dir.join(name);
-            walk_directory(ctx, &child_path, statuses, fingerprint_records)?;
+            walk_directory(
+                ctx,
+                &child_path,
+                DirExpectation::Present,
+                statuses,
+                fingerprint_records,
+            )?;
         }
     }
 
     for (name, entry) in &ward_entries {
         if matches!(entry, WardEntry::Dir {}) && !fs_entries.contains_key(name) {
             let child_path = current_dir.join(name);
-            walk_directory(ctx, &child_path, statuses, fingerprint_records)?;
+            walk_directory(
+                ctx,
+                &child_path,
+                DirExpectation::MaybeRemoved,
+                statuses,
+                fingerprint_records,
+            )?;
         }
     }
 


### PR DESCRIPTION
list_directory mapped both "the directory itself is gone" and "a child vanished between read_dir and symlink_metadata" to Io(NotFound), and the status walk treated that as directory-removed with an empty listing. A single child vanishing mid-listing therefore made an intact directory look empty: status reported everything R, and a fingerprint-less update would rewrite that directory's .treeward as empty, losing all recorded checksums. The two cases now have distinct error variants; only the read_dir open maps to directory-removed, and a vanished child is a fatal concurrent-modification error, consistent with the checksumming policy.

The same reasoning applies one level up: a missing directory is tolerated only when ward state is the sole reason the walk visits it. A directory that was just seen in its parent's listing (or the canonicalized root) but is gone by recursion time is also a concurrent modification and fatal, rather than being silently walked as empty.

The races themselves are not deterministically testable without fault injection, so the test pins the variant mapping the walk's correctness depends on.

changelog: include
