### PR TITLE
fix: reject ward files with malformed sha256 fields at load time

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -21,3 +21,6 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
 - A child entry that vanishes between listing a directory and inspecting it is a fatal error (concurrent modification);
   it is never silently treated as removed. This includes a directory that disappears between being listed and being
   walked. A directory that was already absent when its parent was listed is reported as removed by its parent.
+
+- A `.treeward` file whose `sha256` fields are not exactly 64 lowercase hex characters is rejected as corrupt with a
+  fatal error at load time.

--- a/src/status/tests/basic.rs
+++ b/src/status/tests/basic.rs
@@ -129,7 +129,7 @@ fn test_removed_files() {
     entries.insert(
         "file1.txt".to_string(),
         WardEntry::File {
-            sha256: "abc123".to_string(),
+            sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -164,7 +164,7 @@ fn test_removed_directory() {
     dir1_entries.insert(
         "file1.txt".to_string(),
         WardEntry::File {
-            sha256: "abc123".to_string(),
+            sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -234,7 +234,7 @@ fn test_modified_file_with_verify_changed() {
     entries.insert(
         "file1.txt".to_string(),
         WardEntry::File {
-            sha256: "wrong_checksum".to_string(),
+            sha256: "baadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaad".to_string(),
             mtime_nanos: 1000,
             size: 8,
         },
@@ -308,7 +308,7 @@ fn test_mixed_changes() {
     entries.insert(
         "file2.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },

--- a/src/status/tests/mode_and_fingerprint.rs
+++ b/src/status/tests/mode_and_fingerprint.rs
@@ -150,7 +150,7 @@ fn test_status_mode_all_with_changes() {
     entries.insert(
         "modified.txt".to_string(),
         WardEntry::File {
-            sha256: "wrong_checksum".to_string(),
+            sha256: "baadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaad".to_string(),
             mtime_nanos: 1000,
             size: 8,
         },
@@ -158,7 +158,7 @@ fn test_status_mode_all_with_changes() {
     entries.insert(
         "removed.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -284,8 +284,8 @@ fn test_removed_fingerprint_bound_to_prior_ward_state() {
         result.fingerprint
     };
 
-    let fingerprint1 = fingerprint_for_recorded_sha("aaa");
-    let fingerprint2 = fingerprint_for_recorded_sha("bbb");
+    let fingerprint1 = fingerprint_for_recorded_sha(&"a".repeat(64));
+    let fingerprint2 = fingerprint_for_recorded_sha(&"b".repeat(64));
 
     assert_ne!(
         fingerprint1, fingerprint2,

--- a/src/status/tests/policy.rs
+++ b/src/status/tests/policy.rs
@@ -49,7 +49,7 @@ fn test_checksum_policy_when_possibly_modified_metadata_differs() {
     entries.insert(
         "file1.txt".to_string(),
         WardEntry::File {
-            sha256: "wrong_checksum".to_string(),
+            sha256: "baadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaadbaad".to_string(),
             mtime_nanos: 1000,
             size: 16,
         },
@@ -124,7 +124,7 @@ fn test_checksum_policy_always_with_corruption() {
     entries.insert(
         "file1.txt".to_string(),
         WardEntry::File {
-            sha256: "wrong_checksum_simulating_corruption".to_string(),
+            sha256: "c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de".to_string(),
             mtime_nanos,
             size: metadata.len(),
         },
@@ -159,7 +159,7 @@ fn test_diff_capture_on_checksum_only_difference() {
     let actual_checksum = checksum_file(&root.join("file1.txt")).unwrap();
 
     let recorded_entry = WardEntry::File {
-        sha256: "wrong_checksum_simulating_corruption".to_string(),
+        sha256: "c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de".to_string(),
         mtime_nanos: mtime_to_nanos(&actual_checksum.mtime).unwrap(),
         size: actual_checksum.size,
     };

--- a/src/status/tests/unix.rs
+++ b/src/status/tests/unix.rs
@@ -47,7 +47,7 @@ fn test_symlink_target_changed() {
     entries.insert(
         "target1.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 7,
         },
@@ -55,7 +55,7 @@ fn test_symlink_target_changed() {
     entries.insert(
         "target2.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 7,
         },
@@ -89,7 +89,7 @@ fn test_type_change() {
     entries.insert(
         "item".to_string(),
         WardEntry::File {
-            sha256: "abc123".to_string(),
+            sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -97,7 +97,7 @@ fn test_type_change() {
     entries.insert(
         "target.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 7,
         },

--- a/src/status/tests/ward_update.rs
+++ b/src/status/tests/ward_update.rs
@@ -39,7 +39,7 @@ fn test_display_purpose_without_diff_ward_entry_is_none() {
     entries.insert(
         "modified.txt".to_string(),
         WardEntry::File {
-            sha256: "old_checksum".to_string(),
+            sha256: "01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d0".to_string(),
             mtime_nanos: 1000,
             size: 8,
         },
@@ -47,7 +47,7 @@ fn test_display_purpose_without_diff_ward_entry_is_none() {
     entries.insert(
         "removed.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -115,7 +115,7 @@ fn test_ward_update_purpose_ward_entry_is_some() {
     entries.insert(
         "modified.txt".to_string(),
         WardEntry::File {
-            sha256: "old_checksum".to_string(),
+            sha256: "01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d01d0".to_string(),
             mtime_nanos: 1000,
             size: 8,
         },
@@ -123,7 +123,7 @@ fn test_ward_update_purpose_ward_entry_is_some() {
     entries.insert(
         "removed.txt".to_string(),
         WardEntry::File {
-            sha256: "abc".to_string(),
+            sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca".to_string(),
             mtime_nanos: 1000,
             size: 100,
         },
@@ -214,7 +214,7 @@ fn test_ward_update_checksum_reuse_when_metadata_unchanged() {
 
     // Use a fake checksum that differs from the real one. If checksum reuse
     // works, we'll get this fake one back. If not, we'd get the real checksum.
-    let fake_checksum = "fake_checksum_proving_reuse_works".to_string();
+    let fake_checksum = "fa4e".repeat(16);
 
     let mut entries = BTreeMap::new();
     entries.insert(
@@ -282,7 +282,7 @@ fn test_checksum_policy_always_forces_checksum_even_when_metadata_matches() {
     entries.insert(
         "file.txt".to_string(),
         WardEntry::File {
-            sha256: "wrong_checksum_simulating_corruption".to_string(),
+            sha256: "c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de".to_string(),
             mtime_nanos,
             size: metadata.len(),
         },
@@ -408,7 +408,7 @@ fn test_checksum_policy_never_with_ward_update_content_also_differs() {
     entries.insert(
         "file.txt".to_string(),
         WardEntry::File {
-            sha256: "old_checksum_that_doesnt_match".to_string(),
+            sha256: "deaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead".to_string(),
             mtime_nanos: 1000,
             size: 50,
         },

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -23,6 +23,8 @@ pub enum WardFileError {
     UnsupportedVersion(u32),
     #[error("Invalid ward entry name: {0}")]
     InvalidEntryName(String),
+    #[error("Invalid sha256 for entry {0}: must be 64 lowercase hex characters")]
+    InvalidSha256(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,6 +96,7 @@ impl WardFile {
         // Version is supported, now parse the full file
         let ward_file: WardFile = toml::from_str(content)?;
         ward_file.validate_entry_names()?;
+        ward_file.validate_file_checksums()?;
         Ok(ward_file)
     }
 
@@ -108,6 +111,25 @@ impl WardFile {
         for name in self.entries.keys() {
             if !is_valid_entry_name(name) {
                 return Err(WardFileError::InvalidEntryName(name.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reject persisted checksums that cannot have been produced by checksumming.
+    ///
+    /// treeward always writes sha256 as 64 lowercase hex characters. Anything
+    /// else in a loaded ward file is corruption or tampering and fails fast at
+    /// parse time, consistent with the `deny_unknown_fields` posture. This also
+    /// keeps hostile bytes out of every downstream consumer of the field
+    /// (display, fingerprint hashing).
+    fn validate_file_checksums(&self) -> Result<(), WardFileError> {
+        for (name, entry) in &self.entries {
+            if let WardEntry::File { sha256, .. } = entry
+                && !is_valid_sha256_hex(sha256)
+            {
+                return Err(WardFileError::InvalidSha256(name.clone()));
             }
         }
 
@@ -188,6 +210,12 @@ fn is_valid_entry_name(name: &str) -> bool {
     !name.contains('\0') && Path::new(name).file_name().is_some_and(|part| part == name)
 }
 
+/// Lowercase-only on purpose: treeward never writes uppercase hex, so accepting
+/// it would mask corruption rather than tolerate legitimate input.
+fn is_valid_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,7 +230,7 @@ version = 1
 
 [entries."file1.txt"]
 type = "file"
-sha256 = "abc123"
+sha256 = "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
 mtime_nanos = 1234567890
 size = 42
 "#;
@@ -217,7 +245,10 @@ size = 42
                 mtime_nanos,
                 size,
             } => {
-                assert_eq!(sha256, "abc123");
+                assert_eq!(
+                    sha256,
+                    "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                );
                 assert_eq!(*mtime_nanos, 1234567890);
                 assert_eq!(*size, 42);
             }
@@ -312,6 +343,49 @@ type = "dir"
         assert!(matches!(result, Err(WardFileError::InvalidEntryName(_))));
     }
 
+    /// A sha256 that is not 64 lowercase hex characters is corruption and must
+    /// fail at parse time, before any downstream code (display, fingerprints,
+    /// comparison) sees the value.
+    #[test]
+    fn test_rejects_invalid_sha256() {
+        for bad_sha in [
+            "",
+            "abc123",
+            // Uppercase: treeward never writes it, so it signals corruption.
+            &"A".repeat(64),
+            // Right length, non-hex content.
+            &"g".repeat(64),
+            // Multi-byte UTF-8: 64 bytes but 63 chars, exercising the
+            // byte-level length/charset checks on non-ASCII input.
+            &("a".repeat(11) + "\u{e9}" + &"a".repeat(51)),
+            // 63 and 65 chars.
+            &"a".repeat(63),
+            &"a".repeat(65),
+        ] {
+            let toml_content = format!(
+                r#"
+[metadata]
+version = 1
+
+[entries."file1.txt"]
+type = "file"
+sha256 = "{}"
+mtime_nanos = 123
+size = 456
+"#,
+                bad_sha
+            );
+
+            let result = WardFile::from_toml(&toml_content);
+            assert!(
+                matches!(result, Err(WardFileError::InvalidSha256(ref name)) if name == "file1.txt"),
+                "expected InvalidSha256 for {:?}, got {:?}",
+                bad_sha,
+                result
+            );
+        }
+    }
+
     #[test]
     fn test_corrupted_symlink_missing_target() {
         let toml_content = r#"
@@ -349,7 +423,8 @@ sha256 = "should_be_rejected"
         entries.insert(
             "file1.txt".to_string(),
             WardEntry::File {
-                sha256: "abc123".to_string(),
+                sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                    .to_string(),
                 mtime_nanos: 1234567890,
                 size: 42,
             },
@@ -468,7 +543,8 @@ sha256 = "should_be_rejected"
         entries.insert(
             "test_file.txt".to_string(),
             WardEntry::File {
-                sha256: "test_hash".to_string(),
+                sha256: "7e577e577e577e577e577e577e577e577e577e577e577e577e577e577e577e57"
+                    .to_string(),
                 mtime_nanos: 9876543210,
                 size: 100,
             },
@@ -510,7 +586,8 @@ sha256 = "should_be_rejected"
         entries.insert(
             "test_file.txt".to_string(),
             WardEntry::File {
-                sha256: "test_hash".to_string(),
+                sha256: "7e577e577e577e577e577e577e577e577e577e577e577e577e577e577e577e57"
+                    .to_string(),
                 mtime_nanos: 9876543210,
                 size: 100,
             },
@@ -625,7 +702,7 @@ version = 1
 
 [entries."test.txt"]
 type = "file"
-sha256 = "abc123"
+sha256 = "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
 mtime_nanos = 1234567890
 size = 42
 unknown_field = "should_be_rejected"
@@ -642,7 +719,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "🎉party🎊.txt".to_string(),
             WardEntry::File {
-                sha256: "abc123".to_string(),
+                sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                    .to_string(),
                 mtime_nanos: 1234567890,
                 size: 42,
             },
@@ -680,7 +758,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "ملف.txt".to_string(),
             WardEntry::File {
-                sha256: "abc123".to_string(),
+                sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                    .to_string(),
                 mtime_nanos: 1234567890,
                 size: 42,
             },
@@ -691,7 +770,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file_ملف_mixed.txt".to_string(),
             WardEntry::File {
-                sha256: "def456".to_string(),
+                sha256: "def456def456def456def456def456def456def456def456def456def456def4"
+                    .to_string(),
                 mtime_nanos: 9876543210,
                 size: 100,
             },
@@ -722,7 +802,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             decomposed.clone(),
             WardEntry::File {
-                sha256: "abc123".to_string(),
+                sha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                    .to_string(),
                 mtime_nanos: 1234567890,
                 size: 42,
             },
@@ -730,7 +811,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             precomposed.clone(),
             WardEntry::File {
-                sha256: "def456".to_string(),
+                sha256: "def456def456def456def456def456def456def456def456def456def456def4"
+                    .to_string(),
                 mtime_nanos: 9876543210,
                 size: 100,
             },
@@ -738,7 +820,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             multi_combining.clone(),
             WardEntry::File {
-                sha256: "ghi789".to_string(),
+                sha256: "7897897897897897897897897897897897897897897897897897897897897897"
+                    .to_string(),
                 mtime_nanos: 5555555555,
                 size: 50,
             },
@@ -775,8 +858,14 @@ unknown_field = "should_be_rejected"
                     ..
                 },
             ) => {
-                assert_eq!(sha1, "abc123");
-                assert_eq!(sha2, "def456");
+                assert_eq!(
+                    sha1,
+                    "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
+                );
+                assert_eq!(
+                    sha2,
+                    "def456def456def456def456def456def456def456def456def456def456def4"
+                );
                 assert_eq!(*size1, 42);
                 assert_eq!(*size2, 100);
             }
@@ -791,7 +880,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file with spaces.txt".to_string(),
             WardEntry::File {
-                sha256: "abc".to_string(),
+                sha256: "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca"
+                    .to_string(),
                 mtime_nanos: 1000,
                 size: 10,
             },
@@ -799,7 +889,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file\twith\ttabs.txt".to_string(),
             WardEntry::File {
-                sha256: "def".to_string(),
+                sha256: "defdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefdefd"
+                    .to_string(),
                 mtime_nanos: 2000,
                 size: 20,
             },
@@ -807,7 +898,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file\"with\"quotes.txt".to_string(),
             WardEntry::File {
-                sha256: "ghi".to_string(),
+                sha256: "1212121212121212121212121212121212121212121212121212121212121212"
+                    .to_string(),
                 mtime_nanos: 3000,
                 size: 30,
             },
@@ -815,7 +907,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file\\with\\backslashes.txt".to_string(),
             WardEntry::File {
-                sha256: "jkl".to_string(),
+                sha256: "3434343434343434343434343434343434343434343434343434343434343434"
+                    .to_string(),
                 mtime_nanos: 4000,
                 size: 40,
             },
@@ -823,7 +916,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file=with=equals.txt".to_string(),
             WardEntry::File {
-                sha256: "mno".to_string(),
+                sha256: "5656565656565656565656565656565656565656565656565656565656565656"
+                    .to_string(),
                 mtime_nanos: 5000,
                 size: 50,
             },
@@ -831,7 +925,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file[with]brackets.txt".to_string(),
             WardEntry::File {
-                sha256: "pqr".to_string(),
+                sha256: "7878787878787878787878787878787878787878787878787878787878787878"
+                    .to_string(),
                 mtime_nanos: 6000,
                 size: 60,
             },
@@ -839,7 +934,8 @@ unknown_field = "should_be_rejected"
         entries.insert(
             "file#with#hash.txt".to_string(),
             WardEntry::File {
-                sha256: "stu".to_string(),
+                sha256: "9090909090909090909090909090909090909090909090909090909090909090"
+                    .to_string(),
                 mtime_nanos: 7000,
                 size: 70,
             },


### PR DESCRIPTION
The sha256 field was accepted from .treeward TOML without any validation. The display-side panic this enabled was already fixed (char-based truncation plus escaping, #108), but the root cause remained: a value treeward could never have written was flowing into comparison, fingerprint hashing, and display. Per the corrupted-ward-files-are-fatal policy, parsing now rejects any File entry whose sha256 is not exactly 64 lowercase hex characters. Lowercase-only is deliberate: treeward never writes uppercase, so accepting it would mask corruption rather than tolerate legitimate input. Most of the diff is test fixtures migrating from fake values like "wrong_checksum" to valid 64-hex equivalents.

changelog: include
