### PR TITLE
fix: create ward files with umask-derived permissions instead of 0600

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -24,3 +24,8 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
 
 - A `.treeward` file whose `sha256` fields are not exactly 64 lowercase hex characters is rejected as corrupt with a
   fatal error at load time.
+
+- Written `.treeward` files get standard umask-derived permissions (0666 masked by the process umask), like any normally
+  created file — not owner-only modes that would break `verify` for other users in group-shared trees. NOTE: a readable
+  ward file discloses the sha256, size, and mtime of every sibling entry, including files whose own permissions are more
+  restrictive. Anyone needing those checksums kept private must rely on directory permissions or a stricter umask.

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -168,7 +168,9 @@ impl WardFile {
 
     /// Save a WardFile to the filesystem atomically.
     ///
-    /// Writes to a temporary file, fsyncs it, then atomically renames it into place.
+    /// Writes to a temporary file, fsyncs it, then atomically renames it into
+    /// place. The resulting file gets standard umask-derived permissions, like
+    /// any normally created file.
     pub fn save(&self, path: &Path) -> Result<(), WardFileError> {
         use std::io::Write;
 
@@ -176,7 +178,23 @@ impl WardFile {
 
         let parent = path.parent().unwrap_or(Path::new("."));
 
-        let mut temp_file = tempfile::NamedTempFile::new_in(parent).map_err(|e| {
+        // The only mutation of `builder` is the unix-only permissions()
+        // call below, so non-unix builds would fail -D warnings with
+        // unused_mut without this.
+        #[cfg_attr(not(unix), allow(unused_mut))]
+        let mut builder = tempfile::Builder::new();
+        // NamedTempFile defaults to mode 0600 (right for secrets, wrong here):
+        // persist() carries that to the final file, so every .treeward would
+        // end up owner-only and other users in a group-shared tree would hit
+        // PermissionDenied on verify. Ask for 0666 so the kernel applies the
+        // process umask, matching what File::create would produce.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o666));
+        }
+
+        let mut temp_file = builder.tempfile_in(parent).map_err(|e| {
             if e.kind() == std::io::ErrorKind::PermissionDenied {
                 WardFileError::PermissionDenied(parent.to_path_buf())
             } else {

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -89,6 +89,43 @@ fn init_with_c_flag_changes_directory() {
     assert!(!temp.path().join(".treeward").exists());
 }
 
+/// Ward files must get standard umask-derived permissions, not the 0600 of the
+/// temp file they are staged through. Owner-only ward files break `verify` for
+/// other users in group-shared trees.
+///
+/// Two umask values are checked so a hardcoded mode cannot pass: only actual
+/// masking of 0666 produces both results. The umask is set via `sh` in the
+/// child process only; the test process's own umask is never touched (it is
+/// global state, raceful across threads).
+#[test]
+#[cfg(unix)]
+fn init_creates_ward_files_with_umask_permissions() {
+    for (umask, expected_mode) in [("022", 0o644), ("027", 0o640)] {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("file.txt"), "hello").unwrap();
+
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(r#"umask {} && exec "$0" -C "$1" init"#, umask))
+            .arg(assert_cmd::cargo::cargo_bin!("treeward"))
+            .arg(temp.path())
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let mode = fs::metadata(temp.path().join(".treeward"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, expected_mode,
+            "expected 0666 masked by umask {}",
+            umask
+        );
+    }
+}
+
 /// Verifies that `init` exits with code 255 on errors (e.g., permission denied),
 /// rather than silently succeeding or returning a misleading exit code.
 #[test]


### PR DESCRIPTION
NamedTempFile creates files mode 0600 (right for secrets, wrong for .treeward) and persist() carries that to the final file, so every ward file ended up owner-only regardless of umask and other users in group-shared trees hit fatal PermissionDenied on verify. The temp file is now created requesting 0666 so the kernel applies the process umask, matching what File::create would produce. The test sets umask via sh in a child process only, since the test process's own umask is global state and raceful across threads.

changelog: include
