### PR TITLE
fix: fsync parent directory so ward file writes survive crashes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -32,3 +32,8 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
 
 - Checksumming a path that is no longer a regular file (e.g. swapped for a FIFO or device mid-run) is a fatal error; it
   never blocks waiting on the object.
+
+- On Unix, when `init`/`update` reports success, written `.treeward` files are durable: file contents and the rename
+  into place are both flushed (including a parent-directory fsync) before success is reported. On filesystems that do
+  not support directory fsync (some FUSE and network mounts), and on non-Unix platforms, the rename flush is skipped and
+  durability of the rename is best-effort.

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -3,7 +3,8 @@
 //! This module defines the versioned TOML format that stores per-directory ward
 //! state. Parsing checks file version and schema fields.
 //!
-//! Saving writes through a temp file, fsync, and rename sequence.
+//! Saving writes through a temp file, fsync, and rename sequence, followed on
+//! Unix by a parent-directory fsync so the rename itself is durable.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -168,9 +169,10 @@ impl WardFile {
 
     /// Save a WardFile to the filesystem atomically.
     ///
-    /// Writes to a temporary file, fsyncs it, then atomically renames it into
-    /// place. The resulting file gets standard umask-derived permissions, like
-    /// any normally created file.
+    /// Writes to a temporary file, fsyncs it, atomically renames it into
+    /// place, then (on Unix) fsyncs the parent directory so the rename is
+    /// durable. The resulting file gets standard umask-derived permissions,
+    /// like any normally created file.
     pub fn save(&self, path: &Path) -> Result<(), WardFileError> {
         use std::io::Write;
 
@@ -220,8 +222,46 @@ impl WardFile {
             }
         })?;
 
+        sync_dir(parent)?;
+
         Ok(())
     }
+}
+
+/// Fsync a directory so a preceding rename into it is durable.
+///
+/// `persist` makes the new file's *contents* durable (the temp file was
+/// fsynced), but the rename lives in the directory entry; without flushing the
+/// directory, a crash shortly after a successful save can roll the path back
+/// to the old `.treeward` or none at all. Unacceptable for an integrity tool
+/// that just told the user their state was recorded.
+///
+/// Unix only: std exposes no way to fsync a directory handle on Windows, so
+/// rename durability is not guaranteed there.
+#[cfg(unix)]
+fn sync_dir(dir: &Path) -> Result<(), WardFileError> {
+    let dir_file = std::fs::File::open(dir).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            WardFileError::PermissionDenied(dir.to_path_buf())
+        } else {
+            WardFileError::Io(e)
+        }
+    })?;
+    dir_file.sync_all().or_else(|e| {
+        // Some filesystems (FUSE, network mounts) cannot fsync a directory and
+        // report ENOTSUP/EINVAL/ENOSYS. Failing the whole save would make
+        // treeward unusable there even though the rename succeeded, so accept
+        // the filesystem's best as our best. Real I/O errors still propagate.
+        match e.raw_os_error() {
+            Some(libc::ENOTSUP) | Some(libc::EINVAL) | Some(libc::ENOSYS) => Ok(()),
+            _ => Err(WardFileError::Io(e)),
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn sync_dir(_dir: &Path) -> Result<(), WardFileError> {
+    Ok(())
 }
 
 fn is_valid_entry_name(name: &str) -> bool {


### PR DESCRIPTION
The temp file was fsynced but the rename into place was not: the rename lives in the parent directory entry, so a crash shortly after a successful update could roll the path back to the old .treeward or none at all - while the tool had already told the user their state was recorded. The save sequence now ends with a parent-directory fsync on Unix.

Two deliberate softenings: filesystems that cannot fsync a directory (some FUSE and network mounts return ENOTSUP/EINVAL/ENOSYS) are tolerated rather than making every update fail there, and non-Unix platforms skip the directory flush entirely since std exposes no directory-handle fsync. SPEC.md scopes the durability guarantee accordingly. Not testable without crash injection, so the change is covered by the existing save/load suite plus the documented sequence.

changelog: include
