### PR TITLE
fix: name the offending file when an mtime is outside the supported range

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,9 @@ treeward update  # Always succeeds, no fingerprint check
    immediate children
 2. **Deterministic serialization** - `BTreeMap` ensures stable TOML output
 3. **Error handling philosophy** - Corrupted ward files and permission errors are fatal; never silently skip problems
-4. **High-precision timestamps** - Nanosecond-precision timestamps for accurate modification detection
+4. **High-precision timestamps** - Nanosecond-precision timestamps for accurate modification detection. NOTE: mtimes
+   before the Unix epoch (pre-1970, e.g. from broken tar extracts) or beyond ~year 2554 are unsupported and abort with a
+   fatal error naming the offending file
 5. **Security-conscious** - SHA-256 checksums, concurrent modification detection, TOCTOU protection
 
 ## Development

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,3 +37,7 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
   into place are both flushed (including a parent-directory fsync) before success is reported. On filesystems that do
   not support directory fsync (some FUSE and network mounts), and on non-Unix platforms, the rename flush is skipped and
   durability of the rename is best-effort.
+
+- Files with modification times before the Unix epoch (pre-1970) or beyond the u64 nanosecond range (~year 2554) are not
+  supported: `init`/`status`/`update`/`verify` abort with a fatal error naming the offending file. This is a deliberate
+  limitation of the `mtime_nanos` on-disk format.

--- a/src/status.rs
+++ b/src/status.rs
@@ -466,13 +466,27 @@ fn walk_directory(
     Ok(())
 }
 
-fn mtime_to_nanos(mtime: &std::time::SystemTime) -> Result<u64, StatusError> {
+/// Convert an mtime to the persisted `u64` nanos-since-epoch representation.
+///
+/// Pre-1970 and post-~2554 mtimes do not fit the on-disk format and are a
+/// documented limitation (see SPEC.md): they abort the whole run. The error
+/// names the offending file because the abort is tree-wide and the fix (touch
+/// or re-extract the file) is per-file.
+fn mtime_to_nanos(mtime: &std::time::SystemTime, path: &Path) -> Result<u64, StatusError> {
     let nanos = mtime
         .duration_since(UNIX_EPOCH)
-        .map_err(|_| StatusError::Other("mtime is before UNIX epoch".to_string()))?
+        .map_err(|_| {
+            StatusError::Other(format!(
+                "mtime of {} is before the UNIX epoch; pre-1970 timestamps are not supported",
+                path.display()
+            ))
+        })?
         .as_nanos();
     nanos.try_into().map_err(|_| {
-        StatusError::Other("timestamp overflow: nanoseconds exceeds u64 range".to_string())
+        StatusError::Other(format!(
+            "mtime of {} overflows the supported timestamp range (u64 nanoseconds since epoch)",
+            path.display()
+        ))
     })
 }
 
@@ -488,7 +502,7 @@ fn build_ward_entry_from_fs(
 
             Ok(WardEntry::File {
                 sha256: checksum.sha256,
-                mtime_nanos: mtime_to_nanos(&checksum.mtime)?,
+                mtime_nanos: mtime_to_nanos(&checksum.mtime, &path)?,
                 size: checksum.size,
             })
         }
@@ -609,7 +623,7 @@ fn check_modification(
                 size: fs_size,
             },
         ) => {
-            let fs_mtime_nanos = mtime_to_nanos(fs_mtime)?;
+            let fs_mtime_nanos = mtime_to_nanos(fs_mtime, &absolute_path)?;
             let metadata_differs = fs_mtime_nanos != *ward_mtime_nanos || fs_size != ward_size;
 
             let need_checksum_for_status = match ctx.policy {
@@ -635,7 +649,7 @@ fn check_modification(
                     Some(match &new_checksum {
                         Some(c) => WardEntry::File {
                             sha256: c.sha256.clone(),
-                            mtime_nanos: mtime_to_nanos(&c.mtime)?,
+                            mtime_nanos: mtime_to_nanos(&c.mtime, &absolute_path)?,
                             size: c.size,
                         },
                         None => WardEntry::File {
@@ -838,6 +852,7 @@ fn current_entry_fingerprint_payload(
     ward_entry: Option<&WardEntry>,
     policy: ChecksumPolicy,
 ) -> Result<FingerprintPayload, StatusError> {
+    let path = current_dir.join(name);
     let file_sha256 = if policy != ChecksumPolicy::Never {
         match (fs_entry, ward_entry) {
             (
@@ -846,28 +861,29 @@ fn current_entry_fingerprint_payload(
                     sha256: ward_sha, ..
                 }),
             ) => Some(ward_sha.clone()),
-            (FsEntry::File { .. }, _) => Some(checksum_file(&current_dir.join(name))?.sha256),
+            (FsEntry::File { .. }, _) => Some(checksum_file(&path)?.sha256),
             _ => None,
         }
     } else {
         None
     };
 
-    fingerprint_payload_from_fs_entry(fs_entry, file_sha256)
+    fingerprint_payload_from_fs_entry(fs_entry, file_sha256, &path)
 }
 
 fn fingerprint_payload_from_fs_entry(
     fs_entry: &FsEntry,
     file_sha256: Option<String>,
+    path: &Path,
 ) -> Result<FingerprintPayload, StatusError> {
     match fs_entry {
         FsEntry::File { mtime, size } => Ok(FingerprintPayload::File {
-            mtime_nanos: mtime_to_nanos(mtime)?,
+            mtime_nanos: mtime_to_nanos(mtime, path)?,
             size: *size,
             sha256: file_sha256,
         }),
         FsEntry::Dir { mtime } => Ok(FingerprintPayload::Dir {
-            mtime_nanos: mtime_to_nanos(mtime)?,
+            mtime_nanos: mtime_to_nanos(mtime, path)?,
         }),
         FsEntry::Symlink { symlink_target } => Ok(FingerprintPayload::Symlink {
             symlink_target: symlink_target.clone(),

--- a/src/status/tests/mode_and_fingerprint.rs
+++ b/src/status/tests/mode_and_fingerprint.rs
@@ -296,11 +296,12 @@ fn test_removed_fingerprint_bound_to_prior_ward_state() {
 #[test]
 fn test_mtime_to_nanos_rejects_pre_epoch() {
     let pre_epoch = UNIX_EPOCH - std::time::Duration::from_secs(1);
-    let err = mtime_to_nanos(&pre_epoch).unwrap_err();
+    let err = mtime_to_nanos(&pre_epoch, Path::new("some/old.txt")).unwrap_err();
+    let msg = err.to_string();
     assert!(
-        err.to_string().contains("before UNIX epoch"),
-        "unexpected error: {}",
-        err
+        msg.contains("before the UNIX epoch") && msg.contains("some/old.txt"),
+        "error must explain the limitation and name the file: {}",
+        msg
     );
 }
 
@@ -309,11 +310,12 @@ fn test_mtime_to_nanos_rejects_u64_overflow() {
     // Just past u64::MAX nanoseconds (~year 2554), but still well within what
     // SystemTime can represent on all supported platforms.
     let far_future = UNIX_EPOCH + std::time::Duration::from_secs(18_446_744_074);
-    let err = mtime_to_nanos(&far_future).unwrap_err();
+    let err = mtime_to_nanos(&far_future, Path::new("some/future.txt")).unwrap_err();
+    let msg = err.to_string();
     assert!(
-        err.to_string().contains("overflow"),
-        "unexpected error: {}",
-        err
+        msg.contains("overflow") && msg.contains("some/future.txt"),
+        "error must explain the limitation and name the file: {}",
+        msg
     );
 }
 
@@ -338,10 +340,11 @@ fn test_status_errors_on_pre_epoch_mtime() {
         DiffMode::None,
     )
     .unwrap_err();
+    let msg = err.to_string();
     assert!(
-        err.to_string().contains("before UNIX epoch"),
-        "unexpected error: {}",
-        err
+        msg.contains("before the UNIX epoch") && msg.contains("old.txt"),
+        "error must explain the limitation and name the file: {}",
+        msg
     );
 }
 

--- a/src/status/tests/policy.rs
+++ b/src/status/tests/policy.rs
@@ -160,7 +160,7 @@ fn test_diff_capture_on_checksum_only_difference() {
 
     let recorded_entry = WardEntry::File {
         sha256: "c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de".to_string(),
-        mtime_nanos: mtime_to_nanos(&actual_checksum.mtime).unwrap(),
+        mtime_nanos: mtime_to_nanos(&actual_checksum.mtime, Path::new("file1.txt")).unwrap(),
         size: actual_checksum.size,
     };
     let mut entries = BTreeMap::new();


### PR DESCRIPTION
Pre-1970 (and post-~2554) mtimes abort the whole run, forced by the u64 mtime_nanos on-disk format. This PR accepts that as a deliberate limitation and documents it in SPEC.md rather than changing the format. The narrow fix that IS worth making: the abort previously said "mtime is before UNIX epoch" with no indication of which file, which for a tree-wide failure made the per-file remedy (touch or re-extract) needlessly painful. mtime_to_nanos now takes the path and names the offending file in both error cases.

changelog: include
