### PR TITLE
fix: lower the supported mtime ceiling to what TOML can store

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ treeward update  # Always succeeds, no fingerprint check
 2. **Deterministic serialization** - `BTreeMap` ensures stable TOML output
 3. **Error handling philosophy** - Corrupted ward files and permission errors are fatal; never silently skip problems
 4. **High-precision timestamps** - Nanosecond-precision timestamps for accurate modification detection. NOTE: mtimes
-   before the Unix epoch (pre-1970, e.g. from broken tar extracts) or beyond ~year 2554 are unsupported and abort with a
-   fatal error naming the offending file
+   before the Unix epoch (pre-1970, e.g. from broken tar extracts) or above `i64::MAX` nanoseconds since the epoch
+   (~year 2262) are unsupported and abort with a fatal error naming the offending file
 5. **Security-conscious** - SHA-256 checksums, concurrent modification detection, TOCTOU protection
 
 ## Development

--- a/SPEC.md
+++ b/SPEC.md
@@ -38,6 +38,6 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
   not support directory fsync (some FUSE and network mounts), and on non-Unix platforms, the rename flush is skipped and
   durability of the rename is best-effort.
 
-- Files with modification times before the Unix epoch (pre-1970) or beyond the u64 nanosecond range (~year 2554) are not
-  supported: `init`/`status`/`update`/`verify` abort with a fatal error naming the offending file. This is a deliberate
-  limitation of the `mtime_nanos` on-disk format.
+- Files with modification times before the Unix epoch (pre-1970) or above `i64::MAX` nanoseconds since the epoch
+  (~year 2262) are not supported: `init`/`status`/`update`/`verify` abort with a fatal error naming the offending file.
+  This is a deliberate limitation of the TOML `mtime_nanos` on-disk format: TOML integers are `i64`.

--- a/src/status.rs
+++ b/src/status.rs
@@ -468,10 +468,11 @@ fn walk_directory(
 
 /// Convert an mtime to the persisted `u64` nanos-since-epoch representation.
 ///
-/// Pre-1970 and post-~2554 mtimes do not fit the on-disk format and are a
-/// documented limitation (see SPEC.md): they abort the whole run. The error
-/// names the offending file because the abort is tree-wide and the fix (touch
-/// or re-extract the file) is per-file.
+/// Pre-1970 mtimes and mtimes above `i64::MAX` nanoseconds since the epoch
+/// (around year 2262) do not fit the TOML on-disk format. TOML integers are
+/// `i64`, even though the runtime representation stores `mtime_nanos` as
+/// `u64`. Rejecting them here preserves the documented tree-wide abort while
+/// still naming the file the user needs to fix.
 fn mtime_to_nanos(mtime: &std::time::SystemTime, path: &Path) -> Result<u64, StatusError> {
     let nanos = mtime
         .duration_since(UNIX_EPOCH)
@@ -482,12 +483,13 @@ fn mtime_to_nanos(mtime: &std::time::SystemTime, path: &Path) -> Result<u64, Sta
             ))
         })?
         .as_nanos();
-    nanos.try_into().map_err(|_| {
-        StatusError::Other(format!(
-            "mtime of {} overflows the supported timestamp range (u64 nanoseconds since epoch)",
+    if nanos > i64::MAX as u128 {
+        return Err(StatusError::Other(format!(
+            "mtime of {} overflows the supported timestamp range (i64 nanoseconds since epoch)",
             path.display()
-        ))
-    })
+        )));
+    }
+    Ok(nanos as u64)
 }
 
 fn build_ward_entry_from_fs(

--- a/src/status/tests/mode_and_fingerprint.rs
+++ b/src/status/tests/mode_and_fingerprint.rs
@@ -306,14 +306,20 @@ fn test_mtime_to_nanos_rejects_pre_epoch() {
 }
 
 #[test]
-fn test_mtime_to_nanos_rejects_u64_overflow() {
-    // Just past u64::MAX nanoseconds (~year 2554), but still well within what
-    // SystemTime can represent on all supported platforms.
-    let far_future = UNIX_EPOCH + std::time::Duration::from_secs(18_446_744_074);
+fn test_mtime_to_nanos_rejects_toml_integer_overflow() {
+    let boundary = UNIX_EPOCH
+        + std::time::Duration::from_secs(9_223_372_036)
+        + std::time::Duration::from_nanos(854_775_807);
+    assert_eq!(
+        mtime_to_nanos(&boundary, Path::new("some/boundary.txt")).unwrap(),
+        i64::MAX as u64
+    );
+
+    let far_future = UNIX_EPOCH + std::time::Duration::from_secs(9_223_372_037);
     let err = mtime_to_nanos(&far_future, Path::new("some/future.txt")).unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("overflow") && msg.contains("some/future.txt"),
+        msg.contains("i64 nanoseconds since epoch") && msg.contains("some/future.txt"),
         "error must explain the limitation and name the file: {}",
         msg
     );


### PR DESCRIPTION
`mtime_to_nanos` accepted the full u64 nanosecond range (~year 2554), but
TOML integers are i64, so an mtime in the ~2262-2554 window passed the range
check and then aborted at save time with a generic serialization error that
does not name the offending file -- contradicting SPEC.md's promise that
out-of-range mtimes produce a fatal error naming the file.

Bounding at i64::MAX in mtime_to_nanos keeps the file-naming error and makes
the documented ceiling match what the on-disk format can actually persist.

changelog: include
