### PR TITLE
fix: reject the reserved .treeward entry name in ward files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -25,6 +25,10 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
 - A `.treeward` file whose `sha256` fields are not exactly 64 lowercase hex characters is rejected as corrupt with a
   fatal error at load time.
 
+- A `.treeward` file containing an entry whose name could not have come from scanning a directory — a name with a path
+  separator, `.`, `..`, a NUL byte, or the reserved name `.treeward` itself — is rejected as corrupt with a fatal error
+  at load time.
+
 - Written `.treeward` files get standard umask-derived permissions (0666 masked by the process umask), like any normally
   created file — not owner-only modes that would break `verify` for other users in group-shared trees. NOTE: a readable
   ward file discloses the sha256, size, and mtime of every sibling entry, including files whose own permissions are more

--- a/src/dir_list.rs
+++ b/src/dir_list.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-const TREEWARD_FILENAME: &str = ".treeward";
+pub(crate) const TREEWARD_FILENAME: &str = ".treeward";
 
 #[derive(Debug, thiserror::Error)]
 pub enum DirListError {

--- a/src/ward_file.rs
+++ b/src/ward_file.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use crate::dir_list::TREEWARD_FILENAME;
+
 #[derive(Debug, thiserror::Error)]
 pub enum WardFileError {
     #[error("IO error: {0}")]
@@ -264,8 +266,18 @@ fn sync_dir(_dir: &Path) -> Result<(), WardFileError> {
     Ok(())
 }
 
+/// Returns whether a persisted entry name can come from `list_directory`.
+///
+/// Ward entries name immediate children only. Names containing NUL bytes,
+/// path separators, or `.`/`..` cannot appear as listed children, and
+/// `.treeward` is reserved for the ward file that `list_directory` excludes.
+/// Accepting `.treeward` would let a corrupted ward file make recursive walks
+/// descend into the ward file itself and fail later with a misleading I/O
+/// error instead of rejecting the ward file at parse time.
 fn is_valid_entry_name(name: &str) -> bool {
-    !name.contains('\0') && Path::new(name).file_name().is_some_and(|part| part == name)
+    name != TREEWARD_FILENAME
+        && !name.contains('\0')
+        && Path::new(name).file_name().is_some_and(|part| part == name)
 }
 
 /// Lowercase-only on purpose: treeward never writes uppercase hex, so accepting
@@ -398,6 +410,21 @@ version = 1
 type = "dir"
 "#,
         );
+        assert!(matches!(result, Err(WardFileError::InvalidEntryName(_))));
+    }
+
+    #[test]
+    fn test_rejects_reserved_treeward_entry_name() {
+        let result = WardFile::from_toml(
+            r#"
+[metadata]
+version = 1
+
+[entries.".treeward"]
+type = "dir"
+"#,
+        );
+
         assert!(matches!(result, Err(WardFileError::InvalidEntryName(_))));
     }
 


### PR DESCRIPTION
Directory listing never produces a `.treeward` child, so a persisted
`.treeward` entry can only appear in corrupt or hostile ward files.
Validation accepted it anyway: a Dir-typed entry sent the recursive walk
into the ward file itself, failing with a misleading `Not a directory` IO
error, and a File-typed entry was silently reported Removed and self-healed
on update.

Rejecting the name at parse time matches the existing fail-fast policy for
corrupted ward files.

changelog: include
