### PR TITLE
fix: escape control characters in stderr diagnostics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -15,8 +15,14 @@ Absence of an entry means the behavior is not yet specified, not that it is unsp
   names, symlink targets, or ward-file fields. Control characters (including C1 controls such as the single-byte CSI)
   are rendered as backslash escapes (`\n`, `\t`, `\u{1b}`, ...), and literal backslashes are doubled so escaped output
   is unambiguous; all other Unicode is printed unchanged. This prevents crafted names from injecting terminal escape
-  sequences (OSC/CSI) into the listing. Diagnostic logging (`-v`) and error messages on stderr are NOT covered by this
-  guarantee and may contain raw names.
+  sequences (OSC/CSI) into the listing.
+
+- Diagnostic logging (`-v`) and error messages printed to stderr never emit raw control characters (including C1
+  controls), so crafted names cannot inject terminal escape sequences through diagnostics either. Control characters are
+  rendered in an escaped textual form; the exact rendering is not specified and may differ from the stdout listing's
+  escapes. Command-line usage errors reported while arguments are still being parsed are outside this guarantee: they
+  echo the offending argument verbatim, and the argument came from the invoker rather than from a scanned tree or ward
+  file.
 
 - A child entry that vanishes between listing a directory and inspecting it is a fatal error (concurrent modification);
   it is never silently treated as removed. This includes a directory that disappears between being listed and being

--- a/src/diffing.rs
+++ b/src/diffing.rs
@@ -3,38 +3,11 @@
 //! Formats `status::StatusEntry` values for terminal output and optional
 //! field-level diffs.
 
-use std::borrow::Cow;
 use std::path::Path;
 
 use crate::status;
+use crate::util::escape_control;
 use crate::ward_file::WardEntry;
-
-/// Escape control characters so a crafted file name cannot inject terminal
-/// escape sequences (OSC/CSI) into status output — e.g. retitling the
-/// terminal or writing to the clipboard via OSC 52. Comparable tools (ls,
-/// git) quote control characters for the same reason.
-///
-/// Control characters (including C1, so the single-byte 0x9B CSI is covered)
-/// are rendered with Rust's debug escapes (`\n`, `\u{1b}`, ...). Literal
-/// backslashes are doubled so escaped output stays unambiguous: a name
-/// containing the literal text `\u{1b}` cannot be confused with an escaped
-/// real ESC. All other Unicode passes through unchanged.
-fn escape_control(s: &str) -> Cow<'_, str> {
-    if !s.chars().any(|c| c.is_control() || c == '\\') {
-        return Cow::Borrowed(s);
-    }
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        if c == '\\' {
-            out.push_str("\\\\");
-        } else if c.is_control() {
-            out.extend(c.escape_debug());
-        } else {
-            out.push(c);
-        }
-    }
-    Cow::Owned(out)
-}
 
 /// Format a symlink target for display, escaping control characters.
 /// Non-UTF-8 bytes are replaced lossily; exact-byte fidelity does not
@@ -471,32 +444,6 @@ mod tests {
             format_diff(&entry),
             "   target: /old/target -> /new/target\n"
         );
-    }
-
-    #[test]
-    fn escape_control_passes_plain_names_through() {
-        assert_eq!(escape_control("plain-name.txt"), "plain-name.txt");
-        assert_eq!(escape_control("unicode-ñ-名前.txt"), "unicode-ñ-名前.txt");
-    }
-
-    #[test]
-    fn escape_control_neutralizes_escape_sequences() {
-        // An OSC sequence that would retitle the terminal if printed raw.
-        assert_eq!(
-            escape_control("\x1b]0;pwned\x07.txt"),
-            "\\u{1b}]0;pwned\\u{7}.txt"
-        );
-        // C1 single-byte CSI (U+009B) must be caught too.
-        assert_eq!(escape_control("a\u{9b}31mb"), "a\\u{9b}31mb");
-        assert_eq!(escape_control("line\nbreak"), "line\\nbreak");
-    }
-
-    #[test]
-    fn escape_control_doubles_literal_backslashes() {
-        assert_eq!(escape_control(r"back\slash"), r"back\\slash");
-        // A name containing the literal text "\u{1b}" must stay
-        // distinguishable from a real escaped ESC.
-        assert_eq!(escape_control("fake\\u{1b}.txt"), "fake\\\\u{1b}.txt");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 use update::{WardOptions, ward_directory};
+use util::escape_control;
 
 fn checksum_policy_from_flags(always_verify: bool, verify: bool) -> ChecksumPolicy {
     match (always_verify, verify) {
@@ -315,14 +316,63 @@ where
             }
         }
 
-        ctx.format_fields(writer.by_ref(), event)?;
+        // Escape after field formatting so every stderr diagnostic shares the
+        // same terminal-injection boundary. Individual error types and log
+        // sites should not have to know which strings came from the filesystem
+        // or a ward file.
+        let mut fields = String::new();
+        ctx.format_fields(Writer::new(&mut fields), event)?;
+        writer.write_str(&escape_control(&fields))?;
         writeln!(writer)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::follow_up_verify_flag;
+    use super::{EmojiFormatter, follow_up_verify_flag};
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt as tracing_fmt;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Clone)]
+    struct CapturedWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    struct CapturedWriteGuard {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for CapturedWriteGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturedWriter {
+        type Writer = CapturedWriteGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CapturedWriteGuard {
+                bytes: Arc::clone(&self.bytes),
+            }
+        }
+    }
+
+    struct HostileDisplay;
+
+    impl std::fmt::Display for HostileDisplay {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("hostile \x1b]0;pwned\x07")
+        }
+    }
 
     #[test]
     fn follow_up_hint_uses_verify_when_diff_is_enabled() {
@@ -337,5 +387,34 @@ mod tests {
     #[test]
     fn follow_up_hint_has_no_verify_flag_by_default() {
         assert_eq!(follow_up_verify_flag(false, false, false), "");
+    }
+
+    #[test]
+    fn emoji_formatter_escapes_control_characters_in_event_fields() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let writer = CapturedWriter {
+            bytes: Arc::clone(&bytes),
+        };
+        let layer = tracing_fmt::layer()
+            .event_format(EmojiFormatter {
+                stderr_is_terminal: false,
+            })
+            .with_writer(writer);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(payload = %HostileDisplay, "diagnostic");
+        });
+
+        let output = bytes.lock().unwrap().clone();
+        let stderr = std::str::from_utf8(&output).expect("formatted event should be UTF-8");
+        assert!(
+            stderr.contains(r"payload=hostile \u{1b}]0;pwned\u{7}"),
+            "stderr did not contain escaped event text: {stderr:?}"
+        );
+        assert!(
+            !output.contains(&0x1b),
+            "formatted event contained raw ESC byte: {stderr:?}"
+        );
     }
 }

--- a/src/util/escaping.rs
+++ b/src/util/escaping.rs
@@ -1,0 +1,64 @@
+//! Escaping helpers for terminal-facing text.
+
+use std::borrow::Cow;
+
+/// Escape control characters so untrusted text cannot inject terminal escape sequences.
+///
+/// File names, symlink targets, ward-file fields, and diagnostic messages can
+/// all contain attacker-controlled text. They must not be able to inject
+/// terminal control sequences (OSC/CSI), such as terminal retitling or
+/// clipboard writes via OSC 52. Comparable tools (`ls`, `git`) quote control
+/// characters for the same reason.
+///
+/// Control characters (including C1, so the single-byte 0x9B CSI is covered)
+/// are rendered with Rust's debug escapes (`\n`, `\u{1b}`, ...). Literal
+/// backslashes are doubled so escaped output stays unambiguous: a name
+/// containing the literal text `\u{1b}` cannot be confused with an escaped
+/// real ESC. All other Unicode passes through unchanged.
+pub(crate) fn escape_control(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(|c| c.is_control() || c == '\\') {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c == '\\' {
+            out.push_str("\\\\");
+        } else if c.is_control() {
+            out.extend(c.escape_debug());
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_control;
+
+    #[test]
+    fn escape_control_passes_plain_names_through() {
+        assert_eq!(escape_control("plain-name.txt"), "plain-name.txt");
+        assert_eq!(escape_control("unicode-ñ-名前.txt"), "unicode-ñ-名前.txt");
+    }
+
+    #[test]
+    fn escape_control_neutralizes_escape_sequences() {
+        // An OSC sequence that would retitle the terminal if printed raw.
+        assert_eq!(
+            escape_control("\x1b]0;pwned\x07.txt"),
+            "\\u{1b}]0;pwned\\u{7}.txt"
+        );
+        // C1 single-byte CSI (U+009B) must be caught too.
+        assert_eq!(escape_control("a\u{9b}31mb"), "a\\u{9b}31mb");
+        assert_eq!(escape_control("line\nbreak"), "line\\nbreak");
+    }
+
+    #[test]
+    fn escape_control_doubles_literal_backslashes() {
+        assert_eq!(escape_control(r"back\slash"), r"back\\slash");
+        // A name containing the literal text "\u{1b}" must stay
+        // distinguishable from a real escaped ESC.
+        assert_eq!(escape_control("fake\\u{1b}.txt"), "fake\\\\u{1b}.txt");
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,3 +3,6 @@
 //! Contains helper modules used by multiple internal components.
 
 pub mod hashing;
+
+pub(crate) mod escaping;
+pub(crate) use escaping::escape_control;

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -172,3 +172,47 @@ fn warn_error_emojis_suppressed_when_not_tty() {
         "stderr should include the error message"
     );
 }
+
+/// Hostile filenames must not be able to inject terminal escapes through stderr.
+///
+/// This pins the user-observable guarantee end to end: no raw control bytes
+/// reach the terminal. It deliberately does not pin the exact escaped
+/// rendering of the name — controls embedded in displayed paths may already
+/// be pre-escaped by the standard library (`Path::display()`) in a different
+/// style than the formatter's own `\u{..}` escapes, and either is fine as
+/// long as nothing raw gets through. The formatter unit test in src/main.rs
+/// pins the exact escaping applied at our own boundary.
+#[cfg(unix)]
+#[test]
+fn status_escapes_control_characters_from_unsupported_file_type_errors() {
+    use nix::sys::stat;
+    use nix::unistd;
+
+    let temp = temp_dir_with_file();
+    treeward_cmd(temp.path()).arg("init").assert().success();
+
+    // C0 (ESC, BEL) plus a C1 control (U+009B, the single-byte CSI) so the
+    // spec's "including C1 controls" claim has end-to-end coverage.
+    let hostile_name = "fifo-\x1b]0;pwned\x07\u{9b}31m";
+    unistd::mkfifo(&temp.path().join(hostile_name), stat::Mode::S_IRWXU).unwrap();
+
+    let output = treeward_cmd(temp.path())
+        .arg("status")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    // Strict decoding matters: a raw lone C1 byte (e.g. 0x9B) is invalid
+    // UTF-8, and a lossy decode would launder it into U+FFFD, which
+    // `is_control()` does not catch.
+    let stderr = std::str::from_utf8(&output.stderr).expect("stderr must be valid UTF-8");
+
+    assert!(
+        stderr.contains("fifo-"),
+        "stderr did not name the offending file: {stderr:?}"
+    );
+    assert!(
+        !stderr.chars().any(|c| c.is_control() && c != '\n'),
+        "stderr contained raw control characters: {stderr:?}"
+    );
+}


### PR DESCRIPTION
Status listings on stdout already escape control characters so a crafted
file name cannot inject terminal escape sequences (OSC/CSI), but stderr had
no such boundary: hostile names reached the terminal through error lines
(e.g. the unsupported-file-type error for a FIFO) and `-v` logging.

Escaping is applied centrally in the log formatter rather than at each
error site, so no error type or log call has to know which of its strings
came from the filesystem or a ward file. The guarantee is that no raw
control characters reach stderr; the exact escaped rendering is not pinned,
because controls embedded in displayed paths may already be pre-escaped by
the standard library in a different style than our own escapes.

changelog: include
