### PR TITLE
docs: add dprint fmt to the README development checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Standard Rust idioms apply:
 - `cargo test --locked --all-features --all-targets`
 - `cargo fmt`
 - `cargo clippy --all-targets --all-features -- -D warnings`
+- `dprint fmt` (formats Markdown, TOML, and JSON; CI rejects unformatted files)
 
 ## License
 


### PR DESCRIPTION
CI enforces dprint formatting, but the README's Development section listed
only the cargo checks, so a contributor following it would fail CI on any
Markdown or TOML change.

changelog: skip
